### PR TITLE
added new role variable rke2_additional_sans

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ rke2_ha_mode: false
 rke2_api_ip: "{{ hostvars[groups.masters.0]['ansible_default_ipv4']['address'] }}"
 
 # Add additional SANs in k8s API TLS cert
-additional_sans:
+rke2_additional_sans:
   - api.rke.foo.bar
   - api.k8s.foo.bar
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [<img src="ll-logo.png">](https://lablabs.io/)
 
-This Ansible role will deploy [RKE2](https://docs.rke2.io/) Kubernetes Cluster. RKE2 will be installed using the tarball method.  
+This Ansible role will deploy [RKE2](https://docs.rke2.io/) Kubernetes Cluster. RKE2 will be installed using the tarball method.
 
 The Role can install the RKE2 in 3 modes:
 
@@ -42,6 +42,11 @@ rke2_ha_mode: false
 # In HA mode choose a static IP which will be set as VIP in keepalived.
 rke2_api_ip: "{{ hostvars[groups.masters.0]['ansible_default_ipv4']['address'] }}"
 
+# Add additional SANs in k8s API TLS cert
+additional_sans:
+  - api.rke.foo.bar
+  - api.k8s.foo.bar
+
 # API Server destination port
 rke2_apiserver_dest_port: 6443
 
@@ -60,7 +65,7 @@ rke2_channel_url: https://update.rke2.io/v1-release/channels
 # RKE2 channel
 rke2_channel: stable
 
-# Download Kubernetes config file to the Ansible controller 
+# Download Kubernetes config file to the Ansible controller
 rke2_download_kubeconf: false
 
 # Do not deploy packaged components and delete any deployed components
@@ -83,7 +88,7 @@ rke2_snapshooter: overlayfs
 
 ## Inventory file example
 
-This role relies on nodes distribution to `masters` and `workers` inventory groups. 
+This role relies on nodes distribution to `masters` and `workers` inventory groups.
 The RKE2 Kubernetes master/server nodes must belong to `masters` group and worker/agent nodes must be the members of `workers` group. Both groups has to be the children of `k8s_cluster` group.
 
 ```ini

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -11,6 +11,10 @@ node-taint:
 tls-san:
   - cluster.local
   - {{ rke2_api_ip }}
+{% for san in additional_sans %}
+  - {{ san }}
+{% endfor %}
+
 {% endif %}
 {% if rke2_disable and ( inventory_hostname|string() in groups['masters'] ) %}
 disable: {{ rke2_disable }}
@@ -19,7 +23,7 @@ disable: {{ rke2_disable }}
 kube-apiserver-arg: {{ rke2_kube_apiserver_args}}
 {% endif %}
 {% if ( k8s_node_label is defined ) %}
-node-label: 
+node-label:
 {% for label in k8s_node_label %}
   - {{ label }}
 {% endfor %}

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -11,7 +11,7 @@ node-taint:
 tls-san:
   - cluster.local
   - {{ rke2_api_ip }}
-{% for san in additional_sans %}
+{% for san in rke2_additional_sans %}
   - {{ san }}
 {% endfor %}
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,4 +2,4 @@
 
 # RKE2 installation method (do not change this option)
 rke2_method: tar
-additional_sans: []
+rke2_additional_sans: []

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,3 +2,4 @@
 
 # RKE2 installation method (do not change this option)
 rke2_method: tar
+additional_sans: []


### PR DESCRIPTION
# Pull Request Template

## Description

Added new rke2_additional_sans variable, this offers the TLS SANS in API endpoint. Now you can use an additional DNS entry (maybe you route your endpoint behind your firewall). Otherwise you get an cert error in case of kubectl get....

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Yes

## Destination branch

Create a PR into `develop` branch