### PR TITLE
Add cni variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ rke2_custom_registry_path: templates/registries.yaml.j2
 # Override default containerd snapshotter
 rke2_snapshooter: overlayfs
 
+# Deploy RKE2 with default CNI canal
+rke2_cni: canal
+
 # Download Kubernetes config file to the Ansible controller 
 rke2_download_kubeconf: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,6 +51,9 @@ rke2_custom_registry_path: templates/registries.yaml.j2
 # Override default containerd snapshotter
 rke2_snapshooter: overlayfs
 
+# Deploy RKE2 with default CNI canal
+rke2_cni: canal
+
 # Download Kubernetes config file to the Ansible controller 
 rke2_download_kubeconf: false
 

--- a/tasks/keepalived.yml
+++ b/tasks/keepalived.yml
@@ -40,5 +40,12 @@
     mode: 0644
   notify: restart keepalived
 
+- name: Enable keepalived and make sure it is not masked
+  systemd:
+    name: keepalived
+    enabled: yes
+    masked: no
+  notify: restart keepalived
+
 - name: Flush handlers
   meta: flush_handlers

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -29,3 +29,4 @@ node-label:
 {% endif %}
 snapshotter: {{ rke2_snapshooter }}
 node-name: {{ inventory_hostname }}
+cni: {{ rke2_cni }}


### PR DESCRIPTION
# Description

Added option to configure the CNI. This is needed, for example, if you would like to let a Windows host join the rke2 cluster. Also i added a task to be sure that keepalived is enabled and not masked.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested this by deploying a new cluster. It seems to work.

## Destination branch

Create a PR into `develop` branch