### PR TITLE
Fix hardcoded cluster group name reference

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
   include_tasks: ramaining_nodes.yml
   when:
     - active_server is defined
-    - groups.k8s_cluster | length | int >= 2
+    - groups[rke2_cluster_group_name] | length | int >= 2
 
 - name: Final steps
   include_tasks: summary.yml

--- a/tasks/ramaining_nodes.yml
+++ b/tasks/ramaining_nodes.yml
@@ -42,7 +42,7 @@
   changed_when: false
   register: all_ready_nodes
   until:
-    - groups.k8s_cluster | length == all_ready_nodes.stdout | int
+    - groups[rke2_cluster_group_name] | length == all_ready_nodes.stdout | int
   retries: 100
   delay: 15
   delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"


### PR DESCRIPTION
# Description

Current release fails to honor parameter rke2_cluster_group_name on task includes, overriding the setting with the magic value 'k8s_cluster'

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

The role has been tested on new and existing k8s cluster deployment with the following playbook

```
- name: bootstrap rke cluster

  hosts: rke_cluster

  become: yes

  vars:

    rke2_cluster_group_name: rke_cluster
    rke2_servers_group_name: rke_control
    rke2_download_kubeconf: True
    rke2_download_kubeconf_path: /tmp
    rke2_download_kubeconf_file_name: rke2.yml

  roles:

    - lablabs.rke2

```

## Destination branch

Create a PR into `develop` branch