### PR TITLE
Feature/change script destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ rke2_channel_url: https://update.rke2.io/v1-release/channels
 # e.g. rancher chinase mirror http://rancher-mirror.rancher.cn/rke2/install.sh
 rke2_install_bash_url: https://get.rke2.io
 
+# Destination directory for RKE2 installation script
+rke2_install_script_dir: /var/tmp
+
 # RKE2 channel
 rke2_channel: stable
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,9 @@ rke2_channel_url: https://update.rke2.io/v1-release/channels
 # e.g. rancher chinase mirror http://rancher-mirror.rancher.cn/rke2/install.sh
 rke2_install_bash_url: https://get.rke2.io
 
+# Destination directory for RKE2 installation script
+rke2_install_script_dir: /var/tmp
+
 # RKE2 channel
 rke2_channel: stable
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
     - active_server is not defined
 
 - name: Prepare and join remaining nodes of the cluster
-  include_tasks: ramaining_nodes.yml
+  include_tasks: remaining_nodes.yml
   when:
     - active_server is defined
     - groups[rke2_cluster_group_name] | length | int >= 2

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -3,11 +3,11 @@
 - name: Download RKE2 installation script
   ansible.builtin.get_url:
     url: "{{ rke2_install_bash_url }}"
-    dest: /tmp/rke2.sh
+    dest: "{{ rke2_install_script_dir }}/rke2.sh"
 
 - name: Set the permissions for the file
   file:
-    dest: /tmp/rke2.sh
+    dest: "{{ rke2_install_script_dir }}/rke2.sh"
     mode: 0700
 
 - name: Populate service facts
@@ -25,7 +25,7 @@
 
 - name: Run RKE2 script
   ansible.builtin.command:
-    cmd: /tmp/rke2.sh
+    cmd: "{{ rke2_install_script_dir }}/rke2.sh"
   environment:
     INSTALL_RKE2_VERSION: "{{ rke2_version }}"
     INSTALL_RKE2_CHANNEL_URL: "{{ rke2_channel_url }}"


### PR DESCRIPTION
# Description

The RKE2 installation script has being downloaded and executed from `/tmp` directory. This could cause an issue in case the directory was using `tmpfs` and thus its content was deleted after system reboot. I changed the directory  to /var/tmp. Also the directory is now configurable and can be changed using variable `rke2_install_script_dir`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

molecule
