### PR TITLE
Add static pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ rke2_disable:
 # Path to custom manifests deployed during the RKE2 installation
 rke2_custom_manifests:
 
+# Path to static pods deployed during the RKE2 installation
+rke2_static_pods:
+
 # Deploy RKE2 and set the custom containerd images registries
 rke2_custom_registry: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,9 @@ rke2_disable:
 # Path to custom manifests deployed during the RKE2 installation
 rke2_custom_manifests:
 
+# Path to static pods deployed during the RKE2 installation
+rke2_static_pods:
+
 # Deploy RKE2 and set the custom containerd images registries
 rke2_custom_registry: false
 

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -43,3 +43,13 @@
     mode: 0644
   with_items: "{{ rke2_custom_manifests }}"
   when: rke2_custom_manifests
+
+- name: Copy Static Pods
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: /var/lib/rancher/rke2/agent/pod-manifests/
+    owner: root
+    group: root
+    mode: 0644
+  with_items: "{{ rke2_static_pods }}"
+  when: rke2_static_pods


### PR DESCRIPTION
# Description

Add ability to deploy static pods beside the custom manifests.

As described in: https://docs.rke2.io/architecture/architecture/#initialize-server

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I deployed [kube-vip](https://kube-vip.chipzoller.dev/) with this solution. (I'll raise another PR with that to replace/supplement the keepalived solution)

<!---
Create a PR into `develop` branch
--->