### PR TITLE
Fix optional installation of keepalived

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,8 +5,8 @@
   when:
     - rke2_api_ip is defined
     - inventory_hostname in groups[rke2_servers_group_name]
-    - rke2_ha_mode
-    - rke2_ha_mode_keepalived
+    - rke2_ha_mode | bool
+    - rke2_ha_mode_keepalived | bool
 
 - name: Download and install RKE2
   include_tasks: rke2.yml


### PR DESCRIPTION
# Description

Set `rke2_ha_mode` and `rke2_ha_mode_keepalived` so they will act like a real boolean.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran role with and without this fix:

Setting `rke2_ha_mode_keepalived=false` in inventory then:

Without the fix:
```
TASK [rke2 : Install Keepalived when HA mode is enabled]
included: .../tasks/keepalived.yml for node1, node2, node3
```

With the fix:
```
TASK [rke2 : Install Keepalived when HA mode is enabled]
skipping: [node1]
skipping: [node2]
skipping: [node3]
```
<!---
Create a PR into `develop` branch
--->