### PR TITLE
Use ansible_host from inventory to replace k8s API IP address

### DIFF
--- a/tasks/summary.yml
+++ b/tasks/summary.yml
@@ -14,7 +14,7 @@
   ansible.builtin.replace:
     path: "{{ rke2_download_kubeconf_path }}/{{ rke2_download_kubeconf_file_name }}"
     regexp: '127.0.0.1'
-    replace: "{{ rke2_api_ip | default(hostvars[groups[rke2_servers_group_name].0]['ansible_default_ipv4']['address']) }}"
+    replace: "{{ rke2_api_ip | default(hostvars[groups[rke2_servers_group_name].0].ansible_host) }}"
   delegate_to: localhost
   become: false
   when:


### PR DESCRIPTION
# Description

In some use-cases the `['ansible_default_ipv4']['address']` does not point to the correct interface, this PR aims to fix that by using the `ansible_host` IP address from the inventory.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran my playbook and observe that the first host among masters is being replaced in the `kubeconfig` file.

<!---
Create a PR into `develop` branch
--->