### PR TITLE
Add custom Containerd Registry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,8 @@ jobs:
       max-parallel: 1
       matrix:
         config:
-          - image: "centos8"
+          - image: "rockylinux8"
             tag: "latest"
-          # - image: "rockylinux8"
-          #   tag: "latest"
           - image: "ubuntu2004"
             tag: "latest"
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
         config:
           - image: "centos8"
             tag: "latest"
+          - image: "rockylinux8"
+            tag: "latest"
           - image: "ubuntu2004"
             tag: "latest"
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
         config:
           - image: "centos8"
             tag: "latest"
-          - image: "rockylinux8"
-            tag: "latest"
+          # - image: "rockylinux8"
+          #   tag: "latest"
           - image: "ubuntu2004"
             tag: "latest"
     steps:

--- a/README.md
+++ b/README.md
@@ -87,11 +87,16 @@ rke2_custom_manifests:
 # Path to static pods deployed during the RKE2 installation
 rke2_static_pods:
 
-# Deploy RKE2 and set the custom containerd images registries
-rke2_custom_registry: false
+# Configure custom Containerd Registry
+rke2_custom_registry_mirrors:
+  - name:
+    endpoint: {}
 
 # Path to Container registry config file template
 rke2_custom_registry_path: templates/registries.yaml.j2
+
+# Path to RKE2 config file template
+rke2_config: templates/config.yaml.j2
 
 # Override default containerd snapshotter
 rke2_snapshooter: overlayfs
@@ -133,6 +138,7 @@ rke2_agents_group_name: workers
 # You could find the flags at https://docs.rke2.io/install/install_options/install_options/#configuring-linux-rke2-agent-nodes
 # rke2_agent_options:
 #   - "option: value"
+
 ```
 
 ## Inventory file example

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The Role can install the RKE2 in 3 modes:
 ## Tested on
 
 * CentOS 8
+* Rocky Linux 8
 * Ubuntu 20.04 LTS
 
 ## Role Variables

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ The Role can install the RKE2 in 3 modes:
 
 ## Tested on
 
-* CentOS 8
 * Rocky Linux 8
 * Ubuntu 20.04 LTS
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,11 +53,16 @@ rke2_custom_manifests:
 # Path to static pods deployed during the RKE2 installation
 rke2_static_pods:
 
-# Deploy RKE2 and set the custom containerd images registries
-rke2_custom_registry: false
+# Configure custom Containerd Registry
+rke2_custom_registry_mirrors:
+  - name:
+    endpoint: {}
 
 # Path to Container registry config file template
 rke2_custom_registry_path: templates/registries.yaml.j2
+
+# Path to RKE2 config file template
+rke2_config: templates/config.yaml.j2
 
 # Override default containerd snapshotter
 rke2_snapshooter: overlayfs

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint: |
   ansible-lint --exclude molecule/
 platforms:
   - name: node1
-    image: "geerlingguy/docker-${image:-centos8}-ansible:${tag:-latest}"
+    image: "geerlingguy/docker-${image:-rockylinux8}-ansible:${tag:-latest}"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -6,8 +6,13 @@
     - name: Install packages
       ansible.builtin.package:
         update_cache: true
-        name: "{{ item }}"
-      loop:
-        - wget
-        - curl
-        - iproute
+        name:
+          - wget
+          - curl
+
+    - name: Install special packages for RockyLinux
+      ansible.builtin.package:
+        update_cache: true
+        name:
+          - iproute
+      when: ansible_distribution == "Rocky"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -10,3 +10,4 @@
       loop:
         - wget
         - curl
+        - iproute

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -10,7 +10,7 @@
 
 - name: Copy kubeconfig
   ansible.builtin.template:
-    src: templates/config.yaml.j2
+    src: "{{ rke2_config }}"
     dest: /etc/rancher/rke2/config.yaml
     owner: root
     group: root
@@ -23,7 +23,7 @@
     owner: root
     group: root
     mode: 0644
-  when: rke2_custom_registry | bool
+  when: rke2_custom_registry_mirrors.0.endpoint | length > 0
 
 - name: Start RKE2 service on the first server
   ansible.builtin.systemd:

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -10,7 +10,7 @@
 
 - name: Copy RKE2 config
   ansible.builtin.template:
-    src: templates/config.yaml.j2
+    src: "{{ rke2_custom_config }}"
     dest: /etc/rancher/rke2/config.yaml
     owner: root
     group: root
@@ -23,7 +23,7 @@
     owner: root
     group: root
     mode: 0644
-  when: rke2_custom_registry | bool
+  when: rke2_custom_registry_mirrors.0.endpoint | length > 0
 
 - name: Start RKE2 service on the rest of the nodes
   ansible.builtin.systemd:

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -10,7 +10,7 @@
 
 - name: Copy RKE2 config
   ansible.builtin.template:
-    src: "{{ rke2_custom_config }}"
+    src: "{{ rke2_config }}"
     dest: /etc/rancher/rke2/config.yaml
     owner: root
     group: root

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -10,7 +10,7 @@
 
 - name: Copy RKE2 config
   ansible.builtin.template:
-    src: templates/config.yaml.j2
+    src: "{{ rke2_config }}"
     dest: /etc/rancher/rke2/config.yaml
     owner: root
     group: root
@@ -23,7 +23,7 @@
     owner: root
     group: root
     mode: 0644
-  when: rke2_custom_registry | bool
+  when: rke2_custom_registry_mirrors.0.endpoint | length > 0
 
 - name: Start RKE2 service on the server node
   ansible.builtin.systemd:

--- a/templates/registries.yaml.j2
+++ b/templates/registries.yaml.j2
@@ -1,14 +1,8 @@
 mirrors:
-  docker.io:
+{% for mirror in rke2_custom_registry_mirrors %}
+  {{ mirror.name }}:
     endpoint:
-      - "https://registry.example.com:5000"
-configs:
-  "registry.example.com:5000":
-    auth:
-      username: xxxxxx # this is the registry username
-      password: xxxxxx # this is the registry password
-    tls:
-      cert_file:            # path to the cert file used to authenticate to the registry
-      key_file:             # path to the key file for the certificate used to authenticate to the registry
-      ca_file:              # path to the ca file used to verify the registry's certificate
-      insecure_skip_verify: # may be set to true to skip verifying the registry's certificate
+{% for endpoint in mirror.endpoint %}
+      - "{{ endpoint }}"
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
# Description

[feature] configure custom Containerd Registry mirrors
[feature] allow to define custom path to RKE2 config template ( fixes https://github.com/lablabs/ansible-role-rke2/issues/44 )
[change] replaced tests for  CentoOS 8 (which is EOL) by RockyLinux 8

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Molecule

<!---
Create a PR into `develop` branch
--->