### PR TITLE
Mask other services to prevent accidental start

### DIFF
--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -33,6 +33,12 @@
   environment:
     RKE2_TOKEN: "{{ rke2_token }}"
 
+- name: Mask RKE2 agent service on the first server
+  ansible.builtin.systemd:
+    name: "rke2-agent.service"
+    state: masked
+    enabled: false
+
 - name: Wait for the first server be ready
   shell: |
    set -o pipefail

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -36,8 +36,8 @@
 - name: Mask RKE2 agent service on the first server
   ansible.builtin.systemd:
     name: "rke2-agent.service"
-    state: masked
     enabled: false
+    masked: true
 
 - name: Wait for the first server be ready
   shell: |

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -37,6 +37,14 @@
   environment:
     RKE2_TOKEN: "{{ rke2_token }}"
 
+- name: Mask other RKE2 service on the rest of the nodes
+  ansible.builtin.systemd:
+    name: "rke2-{{ item }}.service"
+    enabled: false
+    masked: true
+  with_items:
+    - "{{ ([ 'agent', 'server' ] | reject('match', rke2_type) | list) }}"
+
 - name: Wait for remaining nodes to be ready
   shell: |
    set -o pipefail


### PR DESCRIPTION
# Description

Adding this code to prevent my colleagues in the future from accidentally starting `rke2-server` on a worker node and vice-verse on master nodes in the future.

## Type of change

- [X] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Excerpt from a playbook run:
```
TASK [rke2 : Mask other RKE2 service on the rest of the nodes] *******************************************************************************************************************************************************
changed: [cmp04-worker] => (item=server)
changed: [cmp03-master] => (item=agent)
changed: [cmp02-master] => (item=agent)
changed: [cmp01-master] => (item=agent)
```

<!---
Create a PR into `develop` branch
--->