### PR TITLE
AirGap Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,19 @@ This playbook will deploy RKE2 to a cluster with one server(master) and several 
 
 ```
 
+This playbook will deploy RKE2 to a cluster with one server(master) and several agent(worker) nodes in air-gapped mode.
+
+```yaml
+- name: Deploy RKE2
+  hosts: all
+  become: yes
+  vars:
+    rke_airgap_mode: true
+  roles:
+     - role: lablabs.rke2
+
+```
+
 This playbook will deploy RKE2 to a cluster with HA server(master) control-plane and several  agent(worker) nodes. The server(master) nodes will be tainted so the workload will be distributed only on worker/agent nodes. The role will install also keepalived on the control-plane nodes and setup VIP address where the Kubernetes API will be reachable. it will also download the Kubernetes config file to the local machine.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ This playbook will deploy RKE2 to a cluster with one server(master) and several 
   hosts: all
   become: yes
   vars:
-    rke_airgap_mode: true
+    rke2_airgap_mode: true
   roles:
      - role: lablabs.rke2
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ rke_type: server
 rke2_ha_mode: false
 
 # Changes the deploy strategy to install based on local artifacts
-rle2-airgap-mode: false
+rke2_airgap_mode: false
 
 # Install and configure Keepalived on Server nodes
 # Can be disabled if you are using pre-configured Load Blancer

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,9 @@ rke_type: server
 # Deploy the control plane in HA mode
 rke2_ha_mode: false
 
+# Changes the deploy strategy to install based on local artifacts
 rle2-airgap-mode: false
+
 # Install and configure Keepalived on Server nodes
 # Can be disabled if you are using pre-configured Load Blancer
 rke2_ha_mode_keepalived: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ rke_type: server
 # Deploy the control plane in HA mode
 rke2_ha_mode: false
 
+rle2-airgap-mode: false
 # Install and configure Keepalived on Server nodes
 # Can be disabled if you are using pre-configured Load Blancer
 rke2_ha_mode_keepalived: true
@@ -104,3 +105,15 @@ rke2_agents_group_name: workers
 # You could find the flags at https://docs.rke2.io/install/install_options/install_options/#configuring-linux-rke2-agent-nodes
 # rke2_agent_options:
 #   - "option: value"
+
+# Default URL to fetch artifacts
+rke2_artifact_url: https://github.com/rancher/rke2/releases/download/
+
+# Local path to store artifacts
+rke2_artifact_path: /rke2/artifact
+
+# Airgap required artifacts
+rke2_artifact: 
+  - sha256sum-amd64.txt
+  - rke2.linux-amd64.tar.gz
+  - rke2-images.linux-amd64.tar.zst

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -42,8 +42,8 @@
     cmd: "{{ rke2_install_script_dir }}/rke2.sh"
   environment:
     INSTALL_RKE2_ARTIFACT_PATH: "{{rke2_artifact_path }}"
-  when: (rke2_version != ( installed_rke2_version.stdout | default({})))
-        or (installed_rke2_version is not defined) and (rke2_airgap_mode)
+  when: (rke2_version != ( installed_rke2_version.stdout | default({})) and (rke2_airgap_mode))
+        or ((installed_rke2_version is not defined) and rke2_airgap_mode)
 
 - name: Run RKE2 script
   ansible.builtin.command:
@@ -53,8 +53,8 @@
     INSTALL_RKE2_CHANNEL_URL: "{{ rke2_channel_url }}"
     INSTALL_RKE2_CHANNEL: "{{ rke2_channel }}"
     INSTALL_RKE2_METHOD: "{{ rke2_method }}"
-  when: (rke2_version != ( installed_rke2_version.stdout | default({})))
-        or installed_rke2_version is not defined and (rke2_airgap_mode == false)
+  when: (rke2_version != ( installed_rke2_version.stdout | default({})) and (rke2_airgap_mode == false))
+        or ((installed_rke2_version is not defined) and (rke2_airgap_mode == false))
 
 - name: Copy Custom Manifests
   ansible.builtin.copy:

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -10,6 +10,20 @@
     dest: "{{ rke2_install_script_dir }}/rke2.sh"
     mode: 0700
 
+- name: Create RKE2 artifact's folder
+  file:
+    path: "{{rke2_artifact_path}}"
+    state: directory
+  when: rle2-airgap-mode
+
+- name: Download RKE2 artifact's
+  ansible.builtin.get_url:
+    url: "{{ rke2_artifact_url }}/{{ rke2_version }}/{{ item }}"
+    dest: "{{ rke2_artifact_path }}/{{ item }}"
+    mode: 0644
+  with_items: "{{ rke2_artifact }}"
+  when: rle2-airgap-mode
+
 - name: Populate service facts
   service_facts:
 
@@ -23,6 +37,14 @@
   register: installed_rke2_version
   when: '"rke2-server.service" in ansible_facts.services'
 
+- name: Run AirGap RKE2 script
+  ansible.builtin.command:
+    cmd: "{{ rke2_install_script_dir }}/rke2.sh"
+  environment:
+    INSTALL_RKE2_ARTIFACT_PATH: "{{rke2_artifact_path }}"
+  when: (rke2_version != ( installed_rke2_version.stdout | default({})))
+        or (installed_rke2_version is not defined) and (rle2-airgap-mode)
+
 - name: Run RKE2 script
   ansible.builtin.command:
     cmd: "{{ rke2_install_script_dir }}/rke2.sh"
@@ -32,7 +54,7 @@
     INSTALL_RKE2_CHANNEL: "{{ rke2_channel }}"
     INSTALL_RKE2_METHOD: "{{ rke2_method }}"
   when: (rke2_version != ( installed_rke2_version.stdout | default({})))
-        or installed_rke2_version is not defined
+        or installed_rke2_version is not defined and (rle2-airgap-mode == false)
 
 - name: Copy Custom Manifests
   ansible.builtin.copy:

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -14,7 +14,7 @@
   file:
     path: "{{rke2_artifact_path}}"
     state: directory
-  when: rle2-airgap-mode
+  when: rke2_airgap_mode
 
 - name: Download RKE2 artifact's
   ansible.builtin.get_url:
@@ -22,7 +22,7 @@
     dest: "{{ rke2_artifact_path }}/{{ item }}"
     mode: 0644
   with_items: "{{ rke2_artifact }}"
-  when: rle2-airgap-mode
+  when: rke2_airgap_mode
 
 - name: Populate service facts
   service_facts:
@@ -43,7 +43,7 @@
   environment:
     INSTALL_RKE2_ARTIFACT_PATH: "{{rke2_artifact_path }}"
   when: (rke2_version != ( installed_rke2_version.stdout | default({})))
-        or (installed_rke2_version is not defined) and (rle2-airgap-mode)
+        or (installed_rke2_version is not defined) and (rke2_airgap_mode)
 
 - name: Run RKE2 script
   ansible.builtin.command:
@@ -54,7 +54,7 @@
     INSTALL_RKE2_CHANNEL: "{{ rke2_channel }}"
     INSTALL_RKE2_METHOD: "{{ rke2_method }}"
   when: (rke2_version != ( installed_rke2_version.stdout | default({})))
-        or installed_rke2_version is not defined and (rle2-airgap-mode == false)
+        or installed_rke2_version is not defined and (rke2_airgap_mode == false)
 
 - name: Copy Custom Manifests
   ansible.builtin.copy:


### PR DESCRIPTION
# Description

This PR downloads needed artifacts from a defined URL variable that can be changed to a private repo. Then changes the RKE script execution environments to point to a local artifacts folder. 

By starting the script with an artifacts environment specified will inform the rke2 install script to run the script from these artifacts instead of from internet sources... aka AirGap.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

I have 4 server setup, 3 masters and 1 Worker. I have run this in both AirGap and Non airgap mode ande the ansible actions are as expected. In the final setup AirGap fully worked and bound the cluster as expected.

<!---
Create a PR into `develop` branch
--->