### PR TITLE
Added feature for AirGap RKE2 Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@
 
 This Ansible role will deploy [RKE2](https://docs.rke2.io/) Kubernetes Cluster. RKE2 will be installed using the tarball method.
 
-The Role can install the RKE2 in 3 modes:
+The Role can install the RKE2 in 4 modes:
 
 - RKE2 single node
 
 - RKE2 Cluster with one Server(Master) node and one or more Agent(Worker) nodes
+
+- RKE2 Cluster using Air-Gapped functionality with the use of artifacts
 
 - RKE2 Cluster with Server(Master) in High Availability mode and zero or more Agent(Worker) nodes. In HA mode you should have an odd number (three recommended) of server(master) nodes that will run etcd, the Kubernetes API (Keepalived VIP address), and other control plane services.
 
@@ -181,6 +183,19 @@ This playbook will deploy RKE2 to a cluster with one server(master) and several 
 - name: Deploy RKE2
   hosts: all
   become: yes
+  roles:
+     - role: lablabs.rke2
+
+```
+
+This playbook will deploy RKE2 to a cluster with one server(master) and several agent(worker) nodes in air-gapped mode. This works from downloading artifacts. When the RKE2 script installs, it will use the artifacts instead of using online resources. 
+
+```yaml
+- name: Deploy RKE2
+  hosts: all
+  become: yes
+  vars:
+    rke2_airgap_mode: true
   roles:
      - role: lablabs.rke2
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,9 @@ rke_type: server
 # Deploy the control plane in HA mode
 rke2_ha_mode: false
 
+# Changes the deploy strategy to install based on local artifacts
+rke2_airgap_mode: false
+
 # Install and configure Keepalived on Server nodes
 # Can be disabled if you are using pre-configured Load Blancer
 rke2_ha_mode_keepalived: true
@@ -104,3 +107,15 @@ rke2_agents_group_name: workers
 # You could find the flags at https://docs.rke2.io/install/install_options/install_options/#configuring-linux-rke2-agent-nodes
 # rke2_agent_options:
 #   - "option: value"
+
+# Default URL to fetch artifacts
+rke2_artifact_url: https://github.com/rancher/rke2/releases/download/
+
+# Local path to store artifacts
+rke2_artifact_path: /rke2/artifact
+
+# Airgap required artifacts
+rke2_artifact: 
+  - sha256sum-amd64.txt
+  - rke2.linux-amd64.tar.gz
+  - rke2-images.linux-amd64.tar.zst

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -10,6 +10,20 @@
     dest: "{{ rke2_install_script_dir }}/rke2.sh"
     mode: 0700
 
+- name: Create RKE2 artifact's folder
+  file:
+    path: "{{rke2_artifact_path}}"
+    state: directory
+  when: rke2_airgap_mode
+
+- name: Download RKE2 artifact's
+  ansible.builtin.get_url:
+    url: "{{ rke2_artifact_url }}/{{ rke2_version }}/{{ item }}"
+    dest: "{{ rke2_artifact_path }}/{{ item }}"
+    mode: 0644
+  with_items: "{{ rke2_artifact }}"
+  when: rke2_airgap_mode
+
 - name: Populate service facts
   service_facts:
 
@@ -23,6 +37,14 @@
   register: installed_rke2_version
   when: '"rke2-server.service" in ansible_facts.services'
 
+- name: Run AirGap RKE2 script
+  ansible.builtin.command:
+    cmd: "{{ rke2_install_script_dir }}/rke2.sh"
+  environment:
+    INSTALL_RKE2_ARTIFACT_PATH: "{{rke2_artifact_path }}"
+  when: (rke2_version != ( installed_rke2_version.stdout | default({})) and (rke2_airgap_mode))
+        or ((installed_rke2_version is not defined) and rke2_airgap_mode)
+
 - name: Run RKE2 script
   ansible.builtin.command:
     cmd: "{{ rke2_install_script_dir }}/rke2.sh"
@@ -31,8 +53,8 @@
     INSTALL_RKE2_CHANNEL_URL: "{{ rke2_channel_url }}"
     INSTALL_RKE2_CHANNEL: "{{ rke2_channel }}"
     INSTALL_RKE2_METHOD: "{{ rke2_method }}"
-  when: (rke2_version != ( installed_rke2_version.stdout | default({})))
-        or installed_rke2_version is not defined
+  when: (rke2_version != ( installed_rke2_version.stdout | default({})) and (rke2_airgap_mode == false))
+        or ((installed_rke2_version is not defined) and (rke2_airgap_mode == false))
 
 - name: Copy Custom Manifests
   ansible.builtin.copy:


### PR DESCRIPTION
# Description

This PR allows the RKE2 ansible setup with an AirGap setup. This is achieved by first downloading the artifacts for RKE2 Release. Then when starting the RKE2 installation script, by defining the aritifact path, the script will begin installation based on local resources instead of internet based. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

3 master, 1 worker cluster with only web proxy available, Ansible runtime evaluated in both airgapped and non airgapped modes enabled. Final result was a fully ready AirGapped cluster.

```yaml
- name: Deploy RKE2
  hosts: all
  become: yes
  vars:
    rke2_ha_mode: true
    rke2_server_taint: true
    rke2_download_kubeconf: true
    rke2_airgap_mode: true
  roles:
     - role: lablabs.rke2
```
<!---
Create a PR into `develop` branch
--->