### PR TITLE
Added feature to set data directory for RKE2

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ rke2_channel_url: https://update.rke2.io/v1-release/channels
 # e.g. rancher chinase mirror http://rancher-mirror.rancher.cn/rke2/install.sh
 rke2_install_bash_url: https://get.rke2.io
 
+# Local data directory for RKE2
+rke2_data_path: /var/lib/rancher/rke2
+
 # Default URL to fetch artifacts
 rke2_artifact_url: https://github.com/rancher/rke2/releases/download/
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,9 @@ rke2_channel_url: https://update.rke2.io/v1-release/channels
 # e.g. rancher chinase mirror http://rancher-mirror.rancher.cn/rke2/install.sh
 rke2_install_bash_url: https://get.rke2.io
 
+# Local data directory for RKE2
+rke2_data_path: /var/lib/rancher/rke2
+
 # Default URL to fetch artifacts
 rke2_artifact_url: https://github.com/rancher/rke2/releases/download/
 

--- a/molecule/cluster/verify.yml
+++ b/molecule/cluster/verify.yml
@@ -8,7 +8,7 @@
       shell: |
         set -e
         set -o pipefail
-        /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep " Ready" | wc -l
+        {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep " Ready" | wc -l
       args:
         executable: /bin/bash
       register: nodes

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -8,7 +8,7 @@
       shell: |
         set -e
         set -o pipefail
-        /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep " Ready" | wc -l
+        {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep " Ready" | wc -l
       args:
         executable: /bin/bash
       register: nodes

--- a/molecule/ha_cluster/verify.yml
+++ b/molecule/ha_cluster/verify.yml
@@ -8,7 +8,7 @@
       shell: |
         set -e
         set -o pipefail
-        /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep " Ready" | wc -l
+        {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep " Ready" | wc -l
       args:
         executable: /bin/bash
       register: nodes

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -42,7 +42,7 @@
 - name: Wait for the first server be ready
   ansible.builtin.shell: |
    set -o pipefail
-   /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep "{{ ansible_hostname }}"
+   {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep "{{ ansible_hostname }}"
   args:
     executable: /bin/bash
   changed_when: false

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -48,7 +48,7 @@
 - name: Wait for remaining nodes to be ready
   ansible.builtin.shell: |
    set -o pipefail
-   /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep " Ready" | wc -l
+   {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep " Ready" | wc -l
   args:
     executable: /bin/bash
   changed_when: false

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -39,6 +39,7 @@
     cmd: "{{ rke2_install_script_dir }}/rke2.sh"
   environment:
     INSTALL_RKE2_ARTIFACT_PATH: "{{ rke2_artifact_path }}"
+    INSTALL_RKE2_AGENT_IMAGES_DIR: "{{ rke2_data_path }}/agent/images"
   when: (rke2_version != ( installed_rke2_version.stdout | default({})) and (rke2_airgap_mode))
         or ((installed_rke2_version is not defined) and rke2_airgap_mode)
 
@@ -56,7 +57,7 @@
 - name: Copy Custom Manifests
   ansible.builtin.copy:
     src: "{{ item }}"
-    dest: /var/lib/rancher/rke2/server/manifests/
+    dest: "{{ rke2_data_path }}/server/manifests/"
     owner: root
     group: root
     mode: 0644
@@ -66,7 +67,7 @@
 - name: Copy Static Pods
   ansible.builtin.copy:
     src: "{{ item }}"
-    dest: /var/lib/rancher/rke2/agent/pod-manifests/
+    dest: "{{ rke2_data_path }}/agent/pod-manifests/"
     owner: root
     group: root
     mode: 0644

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -36,7 +36,7 @@
 - name: Wait for the RKE2 server to be ready
   ansible.builtin.shell: |
    set -o pipefail
-   /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep "{{ ansible_hostname }}"
+   {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep "{{ ansible_hostname }}"
   args:
     executable: /bin/bash
   changed_when: false

--- a/tasks/summary.yml
+++ b/tasks/summary.yml
@@ -24,7 +24,7 @@
     - name: Prepare summary
       ansible.builtin.shell: |
         set -e
-        /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes -o wide --show-labels
+        {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes -o wide --show-labels
       args:
         executable: /bin/bash
       changed_when: false


### PR DESCRIPTION
# Description

Thanks for your work on this ansible role!

For my deployment, I want to move `/var/lib/rancher/rke2` onto a disk mount in another location.

I tried setting `rke2_server_options: data-dir: /mnt/rancher/rke2` but some of the kubectl commands in this role have hard coded paths.

I've made this path a variable, and added it as a default key/value in the config.yaml.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Tested on a local deployment

<!---
Create a PR into `develop` branch
--->