### PR TITLE
Add implementation methods for airgap mode

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Click on `fork` on the top-right corner and fork the repository.
 
 ## 3. Make the changes
 
-Do dthe changes in your own GitHub namespace.
+Do the changes in your own GitHub namespace.
 
 ## 4. Test the changes
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ rke2_ha_mode: false
 # Changes the deploy strategy to install based on local artifacts
 rke2_airgap_mode: false
 
+# Airgap implementation type - download, copy or exists
+# - 'download' will fetch the artifacts on each node,
+# - 'copy' will transfer local files in 'rke2_artifact' to the nodes,
+# - 'exists' assumes 'rke2_artifact' files are already stored in 'rke2_artifact_path'
+rke2_airgap_implementation: download
+
+# Local source path where artifacts are stored
+rke2_airgap_copy_sourcepath: local_artifacts
+
 # Install and configure Keepalived on Server nodes
 # Can be disabled if you are using pre-configured Load Blancer
 rke2_ha_mode_keepalived: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,15 @@ rke2_ha_mode: false
 # Changes the deploy strategy to install based on local artifacts
 rke2_airgap_mode: false
 
+# Airgap implementation type - download, copy or exists
+# - 'download' will fetch the artifacts on each node,
+# - 'copy' will transfer local files in 'rke2_artifact' to the nodes,
+# - 'exists' assumes 'rke2_artifact' files are already stored in 'rke2_artifact_path'
+rke2_airgap_implementation: download
+
+# Local source path where artifacts are stored
+rke2_airgap_copy_sourcepath: local_artifacts
+
 # Install and configure Keepalived on Server nodes
 # Can be disabled if you are using pre-configured Load Blancer
 rke2_ha_mode_keepalived: true

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -5,6 +5,14 @@
     url: "{{ rke2_install_bash_url }}"
     dest: "{{ rke2_install_script_dir }}/rke2.sh"
     mode: 0700
+  when: (not rke2_airgap_mode) or rke2_airgap_implementation == 'download'
+
+- name: Copy local RKE2 installation script
+  ansible.builtin.copy:
+    src: "{{ rke2_airgap_copy_sourcepath }}/rke2.sh"
+    dest: "{{ rke2_install_script_dir }}/rke2.sh"
+    mode: 0700
+  when: rke2_airgap_mode and rke2_airgap_implementation == 'copy'
 
 - name: Create RKE2 artifacts folder
   ansible.builtin.file:
@@ -19,7 +27,15 @@
     dest: "{{ rke2_artifact_path }}/{{ item }}"
     mode: 0644
   with_items: "{{ rke2_artifact }}"
-  when: rke2_airgap_mode
+  when: rke2_airgap_mode and rke2_airgap_implementation == 'download'
+
+- name: Copy local RKE2 artifacts
+  ansible.builtin.copy:
+    src: "{{ rke2_airgap_copy_sourcepath }}/{{ item }}"
+    dest: "{{ rke2_artifact_path }}/{{ item }}"
+    mode: 0644
+  with_items: "{{ rke2_artifact }}"
+  when: rke2_airgap_mode and rke2_airgap_implementation == 'copy'
 
 - name: Populate service facts
   ansible.builtin.service_facts:

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -6,14 +6,14 @@
     dest: "{{ rke2_install_script_dir }}/rke2.sh"
     mode: 0700
 
-- name: Create RKE2 artifact's folder
+- name: Create RKE2 artifacts folder
   ansible.builtin.file:
     path: "{{ rke2_artifact_path }}"
     state: directory
     mode: 0700
   when: rke2_airgap_mode
 
-- name: Download RKE2 artifact's
+- name: Download RKE2 artifacts
   ansible.builtin.get_url:
     url: "{{ rke2_artifact_url }}/{{ rke2_version }}/{{ item }}"
     dest: "{{ rke2_artifact_path }}/{{ item }}"


### PR DESCRIPTION
# Description

Extended airgap mode by allowing for implementations that do not require any access to the internet.
Airgap mode will keep the default behaviour of downloading artifacts on each node, but can also be changed to either copying from a local directory or not doing anything, i.e. assuming the files already exist on the nodes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Each implementation was tested by setting `rke2_airgap_implementation` to the available options and checking if they're behaving as expected, e.g. `copy` not downloading any files.

<!---
Create a PR into `develop` branch
--->