### PR TITLE
Added rolling restart task when the RKE2 version changes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,5 +28,9 @@
     - active_server is defined
     - groups[rke2_cluster_group_name] | length | int >= 2
 
+- name: Rolling restart
+  ansible.builtin.include_tasks: rolling_restart.yml
+  when: installed_rke2_version != rke2_version
+
 - name: Final steps
   ansible.builtin.include_tasks: summary.yml

--- a/tasks/rolling_restart.yml
+++ b/tasks/rolling_restart.yml
@@ -1,0 +1,25 @@
+---
+- name: Rolling Restart RKE2 if version has changed
+  block:
+
+    - name: Restart RKE2 service
+      service:
+        name: rke2-server
+        state: restarted
+
+    - name: Wait for all nodes to be ready again
+      ansible.builtin.shell: |
+        set -o pipefail
+        {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep " Ready" | wc -l
+      args:
+        executable: /bin/bash
+      changed_when: false
+      register: all_ready_nodes
+      until:
+        - groups[rke2_cluster_group_name] | length == all_ready_nodes.stdout | int
+      retries: 100
+      delay: 15
+      delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
+      run_once: true
+
+  throttle: 1


### PR DESCRIPTION
# Description
Issue #61 - When changing RKE2 version, the role installs the new version, but doesn't restart the rke2-server service for it to take effect.

Added a rolling service restart to each host, with a check to make sure k8s is ready on all nodes before starting the next.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Tested locally on a 3 node cluster. Downgraded and upgraded