### PR TITLE
Checksum downloads in airgap mode and add variable to choose architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,12 @@ rke2_artifact_path: /rke2/artifact
 
 # Airgap required artifacts
 rke2_artifact:
-  - sha256sum-amd64.txt
-  - rke2.linux-amd64.tar.gz
-  - rke2-images.linux-amd64.tar.zst
+  - sha256sum-{{ rke2_architecture }}.txt
+  - rke2.linux-{{ rke2_architecture }}.tar.gz
+  - rke2-images.linux-{{ rke2_architecture }}.tar.zst
+
+# Architecture to be downloaded, currently there are releases for amd64 and s390x
+rke2_architecture: amd64
 
 # Destination directory for RKE2 installation script
 rke2_install_script_dir: /var/tmp

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ rke2_airgap_implementation: download
 rke2_airgap_copy_sourcepath: local_artifacts
 
 # Install and configure Keepalived on Server nodes
-# Can be disabled if you are using pre-configured Load Blancer
+# Can be disabled if you are using pre-configured Load Balancer
 rke2_ha_mode_keepalived: true
 
 # Kubernetes API and RKE2 registration IP address. The default Address is the IPv4 of the Server/Master node.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,9 +60,12 @@ rke2_artifact_path: /rke2/artifact
 
 # Airgap required artifacts
 rke2_artifact:
-  - sha256sum-amd64.txt
-  - rke2.linux-amd64.tar.gz
-  - rke2-images.linux-amd64.tar.zst
+  - sha256sum-{{ rke2_architecture }}.txt
+  - rke2.linux-{{ rke2_architecture }}.tar.gz
+  - rke2-images.linux-{{ rke2_architecture }}.tar.zst
+
+# Architecture to be downloaded, currently there are releases for amd64 and s390x
+rke2_architecture: amd64
 
 # Destination directory for RKE2 installation script
 rke2_install_script_dir: /var/tmp

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -12,6 +12,7 @@
     src: "{{ rke2_airgap_copy_sourcepath }}/rke2.sh"
     dest: "{{ rke2_install_script_dir }}/rke2.sh"
     mode: 0700
+    force: yes
   when: rke2_airgap_mode and rke2_airgap_implementation == 'copy'
 
 - name: Create RKE2 artifacts folder
@@ -21,12 +22,21 @@
     mode: 0700
   when: rke2_airgap_mode
 
-- name: Download RKE2 artifacts
-  ansible.builtin.get_url:
-    url: "{{ rke2_artifact_url }}/{{ rke2_version }}/{{ item }}"
-    dest: "{{ rke2_artifact_path }}/{{ item }}"
-    mode: 0644
-  with_items: "{{ rke2_artifact }}"
+- name: Download RKE2 checksum and artifacts
+  block:
+  - name: Download sha256 checksum file
+    ansible.builtin.get_url:
+      url: "{{ rke2_artifact_url }}/{{ rke2_version }}/sha256sum-{{ rke2_architecture }}.txt"
+      dest: "{{ rke2_artifact_path }}/sha256sum-{{ rke2_architecture }}.txt"
+      force: yes
+      mode: 0644
+  - name: Download RKE2 artifacts and compare with checksums
+    ansible.builtin.get_url:
+      url: "{{ rke2_artifact_url }}/{{ rke2_version }}/{{ item }}"
+      dest: "{{ rke2_artifact_path }}/{{ item }}"
+      mode: 0644
+      checksum: "sha256:{{ rke2_artifact_url }}{{ rke2_version }}/sha256sum-{{ rke2_architecture }}.txt"
+    with_items: "{{ rke2_artifact | reject('search','sha256sum') | list }}"
   when: rke2_airgap_mode and rke2_airgap_implementation == 'download'
 
 - name: Copy local RKE2 artifacts
@@ -34,6 +44,7 @@
     src: "{{ rke2_airgap_copy_sourcepath }}/{{ item }}"
     dest: "{{ rke2_artifact_path }}/{{ item }}"
     mode: 0644
+    force: yes
   with_items: "{{ rke2_artifact }}"
   when: rke2_airgap_mode and rke2_airgap_implementation == 'copy'
 

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -44,7 +44,7 @@ vrrp_instance VI_1 {
         auth_type PASS
         auth_pass rke2servers
     }
-### The following entry is the VRRP config for the incomming interface ###
+### The following entry is the VRRP config for the incoming interface ###
 
         virtual_ipaddress {
             {{ rke2_api_ip }}


### PR DESCRIPTION
# Description

We noticed that new versions of rke2 were not actually being downloaded in airgap mode if there already exist files with the same name on the filesystem, so now the checksum file is always being downloaded and checksum of artifacts is checked against it to make sure we get the correct files.

Also added a variable to choose desired architecture, this defaults to amd64.

<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Tested airgap mode 'download' on an HA cluster running on VMs
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
