### PR TITLE
changing default variable to match used variable in "remaining_nodes.yml"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This is a copy of `defaults/main.yml`
 ---
 
 # The node type - server or agent
-rke_type: server
+rke2_type: server
 
 # Deploy the control plane in HA mode
 rke2_ha_mode: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 # The node type - server or agent
-rke_type: server
+rke2_type: server
 
 # Deploy the control plane in HA mode
 rke2_ha_mode: false


### PR DESCRIPTION
Defaults result in errors due to default "rke_type" vs "rke2_type".

"remaining_nodes.yml" errors out as it is expecting "rke2_type"