### PR TITLE
Fix keepalived to check healthz API endpoint

### DIFF
--- a/templates/check_apiserver.sh.j2
+++ b/templates/check_apiserver.sh.j2
@@ -3,7 +3,7 @@ errorExit() {
     echo "*** $*" 1>&2
     exit 1
 }
-curl --silent --max-time 2 --insecure https://localhost:{{rke2_apiserver_dest_port}}/ -o /dev/null || errorExit "Error GET https://localhost:{{rke2_apiserver_dest_port}}/"
+curl --silent --max-time 2 --insecure https://localhost:{{rke2_apiserver_dest_port}}/healthz --cert {{rke2_data_path}}/server/tls/client-ca.crt --key {{rke2_data_path}}/server/tls/client-ca.key -o /dev/null || errorExit "Error GET https://localhost:{{rke2_apiserver_dest_port}}/healthz"
 if ip addr | grep -q {{rke2_api_ip}}; then
-    curl --silent --max-time 2 --insecure https://{{rke2_api_ip}}:{{rke2_apiserver_dest_port}}/ -o /dev/null || errorExit "Error GET https://{{rke2_api_ip}}:{{rke2_apiserver_dest_port}}/"
+    curl --silent --max-time 2 --insecure https://{{rke2_api_ip}}:{{rke2_apiserver_dest_port}}/healthz --cert {{rke2_data_path}}/server/tls/client-ca.crt --key {{rke2_data_path}}/server/tls/client-ca.key -o /dev/null || errorExit "Error GET https://{{rke2_api_ip}}:{{rke2_apiserver_dest_port}}/healthz"
 fi


### PR DESCRIPTION
# Description

Keepalived health-check script will now check the `healthz` API endpoint. Fixes #60 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Molecule. Node in `NotReady` state was failed over. 
