### PR TITLE
Keepalived selinux

### DIFF
--- a/tasks/keepalived.yml
+++ b/tasks/keepalived.yml
@@ -21,25 +21,47 @@
     owner: root
     group: root
     mode: 0755
-
-- name: Create Kubernetes API health check script
-  ansible.builtin.template:
+    
+- name: Create Kubernetes API health check script for Debian OS family
+  template:
     src: templates/check_apiserver.sh.j2
     dest: /etc/keepalived/check_apiserver.sh
     owner: root
     group: root
     mode: 0755
+  when:  ansible_facts['os_family'] == "Debian"
   notify: restart keepalived
 
-- name: Create RKE2 Server health check script
+- name: Create Kubernetes API health check script for RedHat OS famliy
+  template:
+    src: templates/check_apiserver.sh.j2
+    dest: /usr/libexec/keepalived/check_apiserver.sh
+    owner: root
+    group: root
+    mode: 0755
+  when:  ansible_facts['os_family'] == "RedHat"
+  notify: restart keepalived
+
+- name: Create RKE2 Server health check script for Debian OS family
   ansible.builtin.template:
     src: templates/check_rke2server.sh.j2
     dest: /etc/keepalived/check_rke2server.sh
     owner: root
     group: root
     mode: 0755
+  when:  ansible_facts['os_family'] == "Debian"
   notify: restart keepalived
 
+- name: Create RKE2 Server health check script for RedHat OS family
+  ansible.builtin.template:
+    src: templates/check_rke2server.sh.j2
+    dest: /usr/libexec/keepalived/check_rke2server.sh
+    owner: root
+    group: root
+    mode: 0755
+  when:  ansible_facts['os_family'] == "RedHat"
+  notify: restart keepalived
+  
 - name: Create keepalived config file
   ansible.builtin.template:
     src: templates/keepalived.conf.j2

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -16,7 +16,11 @@ vrrp_script chk_apiserver {
 
 
 vrrp_script chk_rke2server {
+{% if ansible_facts['os_family'] == "RedHat" %}
+    script "/usr/libexec/keepalived/check_rke2server.sh"
+{% else %}
     script "/etc/keepalived/check_rke2server.sh"
+{% endif %}
     interval 2
     weight -5
     fall 3

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -3,12 +3,17 @@ global_defs {
 }
 
 vrrp_script chk_apiserver {
+{% if ansible_facts['os_family'] == "RedHat" %}
+       script "/usr/libexec/keepalived/check_apiserver.sh"
+{% else %}
     script "/etc/keepalived/check_apiserver.sh"
+{% endif %}
     interval 2
     weight -5
     fall 3
     rise 2
 }
+
 
 vrrp_script chk_rke2server {
     script "/etc/keepalived/check_rke2server.sh"


### PR DESCRIPTION
# Description

<!---
The keepalived service lacks SELinux privleges to exec commands directly as scripts, including tracking scripts and notification scripts, outside the /usr/libexec/keepalived directory. 
SELinux prevents executing scripts from /etc/keepalived 
--->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
Keepalived scripts have been moved into /usr/libexec/keepalived and pointed the keepalived.conf to the new location.
SELinux stopped denying the execution of the scripts