### PR TITLE
Detect if /usr/local is writeable else check in /opt/rke2

### DIFF
--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -51,10 +51,19 @@
 - name: Populate service facts
   ansible.builtin.service_facts:
 
-- name: Check RKE2 version
+- name: Get stats of the FS object
+  ansible.builtin.stat:
+    path: /usr/local
+  register: usr_local
+
+- name: Set RKE2 bin path
+  set_fact:
+    rke2_bin_path: "{{ '/usr/local/bin/rke2' if  usr_local.stat.writeable == True else ' /opt/rke2/bin/rke2' }}"
+
+- name: Check RKE2 version usr local location
   ansible.builtin.shell: |
     set -o pipefail
-    /usr/local/bin/rke2 --version | grep -E "rke2 version" | awk '{print $3}'
+    {{ rke2_bin_path }} --version | grep -E "rke2 version" | awk '{print $3}'
   args:
     executable: /bin/bash
   changed_when: false


### PR DESCRIPTION
# Description

Trying to solve that the install scripts write the binary to /opt instead of in usr/local

https://github.com/lablabs/ansible-role-rke2/issues/70

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ x } Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Testes it by roll out in flatcar where /usr/local is mounted read only
