### PR TITLE
Fix: Use rke2_cluster_group_name variable for Rolling restart

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
 
 - name: Rolling restart
   ansible.builtin.include_tasks: rolling_restart.yml
-  with_items: "{{ groups.k8s_cluster }}"
+  with_items: "{{ groups[rke2_cluster_group_name] }}"
   loop_control:
     loop_var: _host_item
   when: ( hostvars[_host_item].inventory_hostname == inventory_hostname ) and installed_rke2_version.stdout is defined and rke2_version != ( installed_rke2_version.stdout | default({}) )


### PR DESCRIPTION
# Description

Currently, the Rolling restart task doesn't use the `rke2_cluster_group_name` variable, instead, it is hardcoded as `groups.k8s_cluster `. This PR solves this issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Ubuntu 20.04 virtual machines