### PR TITLE
ci: fix push to galaxy on release

### DIFF
--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -2,9 +2,8 @@
 name: Release to Ansible Galaxy
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 jobs:
   release:


### PR DESCRIPTION
# Description

GHA pipeline for releasing to Ansible Galaxy does not work when released from release draft created by release-drafter. This PR will fix it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
pipeline test
