### PR TITLE
Support extra tains per node, and merge with rke2_server_taint if set true

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+# Default nodetaints
+node_taints: []
 
 # The node type - server or agent
 rke2_type: server

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -13,6 +13,11 @@
     combined_node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
   when: rke2_server_taint and rke2_type == 'server'
 
+- name: if agent set combined_node_taints to node_taints
+  set_fact:
+    combined_node_taints: "{{ node_taints }}"
+  when: rke2_type == 'agent' or rke2_server_taint == false
+
 - name: Copy rke2 config
   ansible.builtin.template:
     src: "{{ rke2_config }}"

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -10,7 +10,7 @@
 
 - name: append "CriticalAddonsOnly=true:NoExecute" to node_taints if rke2_server_taint is set
   set_fact:
-    combined_node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
+    node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
   when: rke2_server_taint and rke2_type == 'server'
 
 - name: Copy rke2 config

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -13,9 +13,6 @@
     combined_node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
   when: rke2_server_taint and rke2_type == 'server'
 
-- debug: "var=combined_node_taints"
-
-
 - name: Copy rke2 config
   ansible.builtin.template:
     src: "{{ rke2_config }}"

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -10,7 +10,7 @@
 
 - name: append "CriticalAddonsOnly=true:NoExecute" to node_taints if rke2_server_taint is set
   set_fact:
-    node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
+    combined_node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
   when: rke2_server_taint and rke2_type == 'server'
 
 - name: Copy rke2 config

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -16,7 +16,7 @@
 - name: if agent set combined_node_taints to node_taints
   set_fact:
     combined_node_taints: "{{ node_taints }}"
-  when: rke2_type == 'agent' or rke2_server_taint == false
+  when: rke2_type == 'agent' or not rke2_server_taint
 
 - name: Copy rke2 config
   ansible.builtin.template:

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -10,7 +10,7 @@
 
 - name: append "CriticalAddonsOnly=true:NoExecute" to node_taints if rke2_server_taint is set
   set_fact:
-    ec2_security_group_names: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
+    node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
   when: rke2_server_taint and rke2_type == 'server'
 
 - name: Copy rke2 config

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -8,6 +8,11 @@
     group: root
     mode: 0755
 
+- name: append "CriticalAddonsOnly=true:NoExecute" to node_taints if rke2_server_taint is set
+  set_fact:
+    ec2_security_group_names: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
+  when: rke2_server_taint and rke2_type == 'server'
+
 - name: Copy rke2 config
   ansible.builtin.template:
     src: "{{ rke2_config }}"

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -13,6 +13,9 @@
     node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
   when: rke2_server_taint and rke2_type == 'server'
 
+- debug: "var=node_taints"
+
+
 - name: Copy rke2 config
   ansible.builtin.template:
     src: "{{ rke2_config }}"

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -8,12 +8,12 @@
     group: root
     mode: 0755
 
-- name: append "CriticalAddonsOnly=true:NoExecute" to node_taints if rke2_server_taint is set
+- name: Set server taints
   set_fact:
     combined_node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
   when: rke2_server_taint and rke2_type == 'server'
 
-- name: if agent set combined_node_taints to node_taints
+- name: Set agent taints
   set_fact:
     combined_node_taints: "{{ node_taints }}"
   when: rke2_type == 'agent' or not rke2_server_taint

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -10,10 +10,10 @@
 
 - name: append "CriticalAddonsOnly=true:NoExecute" to node_taints if rke2_server_taint is set
   set_fact:
-    node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
+    combined_node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
   when: rke2_server_taint and rke2_type == 'server'
 
-- debug: "var=node_taints"
+- debug: "var=combined_node_taints"
 
 
 - name: Copy rke2 config

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -8,6 +8,11 @@
     group: root
     mode: 0755
 
+- name: append "CriticalAddonsOnly=true:NoExecute" to node_taints if rke2_server_taint is set
+  set_fact:
+    ec2_security_group_names: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
+  when: rke2_server_taint and rke2_type == 'server'
+
 - name: Copy RKE2 config
   ansible.builtin.template:
     src: "{{ rke2_config }}"

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -10,7 +10,7 @@
 
 - name: append "CriticalAddonsOnly=true:NoExecute" to node_taints if rke2_server_taint is set
   set_fact:
-    node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
+    combined_node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
   when: rke2_server_taint and rke2_type == 'server'
 
 - debug: "var=node_taints"

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -13,6 +13,11 @@
     combined_node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
   when: rke2_server_taint and rke2_type == 'server'
 
+- name: if agent set combined_node_taints to node_taints
+  set_fact:
+    combined_node_taints: "{{ node_taints }}"
+  when: rke2_type == 'agent'
+
 - debug: "var=combined_node_taints"
 
 - name: Copy RKE2 config

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -13,7 +13,7 @@
     combined_node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
   when: rke2_server_taint and rke2_type == 'server'
 
-- debug: "var=node_taints"
+- debug: "var=combined_node_taints"
 
 - name: Copy RKE2 config
   ansible.builtin.template:

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -10,7 +10,7 @@
 
 - name: append "CriticalAddonsOnly=true:NoExecute" to node_taints if rke2_server_taint is set
   set_fact:
-    ec2_security_group_names: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
+    node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
   when: rke2_server_taint and rke2_type == 'server'
 
 - name: Copy RKE2 config

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -13,6 +13,8 @@
     node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
   when: rke2_server_taint and rke2_type == 'server'
 
+- debug: "var=node_taints"
+
 - name: Copy RKE2 config
   ansible.builtin.template:
     src: "{{ rke2_config }}"

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -18,8 +18,6 @@
     combined_node_taints: "{{ node_taints }}"
   when: rke2_type == 'agent'
 
-- debug: "var=combined_node_taints"
-
 - name: Copy RKE2 config
   ansible.builtin.template:
     src: "{{ rke2_config }}"

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -16,7 +16,7 @@
 - name: if agent set combined_node_taints to node_taints
   set_fact:
     combined_node_taints: "{{ node_taints }}"
-  when: rke2_type == 'agent' or rke2_server_taint == false
+  when: rke2_type == 'agent' or not rke2_server_taint
 
 - name: Copy RKE2 config
   ansible.builtin.template:

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -16,7 +16,7 @@
 - name: if agent set combined_node_taints to node_taints
   set_fact:
     combined_node_taints: "{{ node_taints }}"
-  when: rke2_type == 'agent'
+  when: rke2_type == 'agent' or rke2_server_taint == false
 
 - name: Copy RKE2 config
   ansible.builtin.template:

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -8,12 +8,12 @@
     group: root
     mode: 0755
 
-- name: append "CriticalAddonsOnly=true:NoExecute" to node_taints if rke2_server_taint is set
+- name: Set server taints
   set_fact:
     combined_node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
   when: rke2_server_taint and rke2_type == 'server'
 
-- name: if agent set combined_node_taints to node_taints
+- name: Set agent taints
   set_fact:
     combined_node_taints: "{{ node_taints }}"
   when: rke2_type == 'agent' or not rke2_server_taint

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -5,9 +5,9 @@ server: https://{{ rke2_api_ip }}:9345
 token: {{ rke2_token }}
 {% if inventory_hostname in groups[rke2_servers_group_name] %}
 cni: {{ rke2_cni }}
-{% if ( combined_node_taints is defined and combined_node_taints|length > 0) %}
+{% if ( node_taints is defined and node_taints|length > 0) %}
 node-taint:
-{% for taint in combined_node_taints %}
+{% for taint in node_taints %}
   - {{ taint }}
 {% endfor %}
 {% endif %}

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -5,9 +5,13 @@ server: https://{{ rke2_api_ip }}:9345
 token: {{ rke2_token }}
 {% if inventory_hostname in groups[rke2_servers_group_name] %}
 cni: {{ rke2_cni }}
-{% if rke2_server_taint %}
+
+
+{% if ( node_taints is defined and node_taints|length > 0) %}
 node-taint:
-  - "CriticalAddonsOnly=true:NoExecute"
+{% for taint in node_taints %}
+  - {{ taint }}
+{% endfor %}
 {% endif %}
 tls-san:
   - cluster.local

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -5,9 +5,9 @@ server: https://{{ rke2_api_ip }}:9345
 token: {{ rke2_token }}
 {% if inventory_hostname in groups[rke2_servers_group_name] %}
 cni: {{ rke2_cni }}
-{% if ( node_taints is defined and node_taints|length > 0) %}
+{% if ( combined_node_taints is defined and combined_node_taints|length > 0) %}
 node-taint:
-{% for taint in node_taints %}
+{% for taint in combined_node_taints %}
   - {{ taint }}
 {% endfor %}
 {% endif %}

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -5,8 +5,6 @@ server: https://{{ rke2_api_ip }}:9345
 token: {{ rke2_token }}
 {% if inventory_hostname in groups[rke2_servers_group_name] %}
 cni: {{ rke2_cni }}
-
-
 {% if ( node_taints is defined and node_taints|length > 0) %}
 node-taint:
 {% for taint in node_taints %}


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
I have been rolling it out multiple times with rke2_server_taint set as false, true etc
And triede setting node_taints: -items for masters only, and for agents.
