### PR TITLE
feat: option to disable kube-vip LB

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ rke2_api_ip: "{{ hostvars[groups[rke2_servers_group_name].0]['ansible_default_ip
 # optiononal option for kubevip load balancer IP range
 # rke2_loadbalancer_ip_range: 192.168.1.50-192.168.1.100
 
+# Disable deployment of kubevip Service LB when rke2_ha_mode_kubevip is true
+rke2_kubevip_lb_disable: false
+
 # Add additional SANs in k8s API TLS cert
 rke2_additional_sans: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,9 @@ rke2_api_ip: "{{ hostvars[groups[rke2_servers_group_name].0]['ansible_default_ip
 # optiononal option for kubevip load balancer IP range
 # rke2_loadbalancer_ip_range: 192.168.1.50-192.168.1.100
 
+# Disable deployment of kubevip Service LB when rke2_ha_mode_kubevip is true
+rke2_kubevip_lb_disable: false
+
 # Add additional SANs in k8s API TLS cert
 rke2_additional_sans: []
 

--- a/tasks/kubevip.yml
+++ b/tasks/kubevip.yml
@@ -1,5 +1,5 @@
 ---
-- name: Copy kube-vip files to first server
+- name: Copy kube-vip AH manifests to first server
   ansible.builtin.template:
     src: "{{ item }}"
     dest: "{{ rke2_data_path }}/server/manifests/{{ item | basename | regex_replace('.j2$', '') }}"
@@ -7,4 +7,17 @@
     group: root
     mode: 0664
   with_fileglob:
-    - "templates/kube-vip/*.j2"
+    - "templates/kube-vip/kube-vip.yml.j2"
+    - "templates/kube-vip/kube-vip-rbac.yml.j2"
+
+- name: Copy kube-vip load balancer manifests to first server
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: "{{ rke2_data_path }}/server/manifests/{{ item | basename | regex_replace('.j2$', '') }}"
+    owner: root
+    group: root
+    mode: 0664
+  with_fileglob:
+    - "templates/kube-vip/kube-vip-cloud-*.j2"
+  when:
+    - not rke2_kubevip_lb_disable | bool


### PR DESCRIPTION
# Description

Provides an option to disable the deployment of the kube-vip cloud provider manifests for service load balancing allowing deployment of kube-vip AH only if one wants to use another service load balancer such as metallb.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Tested deployment with new option `rke2_kubevip_lb_disable` set to true.