### PR TITLE
feat: option to install of kubevip cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ rke2_api_ip: "{{ hostvars[groups[rke2_servers_group_name].0]['ansible_default_ip
 # optiononal option for kubevip load balancer IP range
 # rke2_loadbalancer_ip_range: 192.168.1.50-192.168.1.100
 
+# Install kubevip cloud provider if rke2_ha_mode_kubevip is true
+rke2_kubevip_cloud_provider_enable: true
+
+# Enable kube-vip to watch Services of type LoadBalancer
+rke2_kubevip_svc_enable: true
+
 # Add additional SANs in k8s API TLS cert
 rke2_additional_sans: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,12 @@ rke2_api_ip: "{{ hostvars[groups[rke2_servers_group_name].0]['ansible_default_ip
 # optiononal option for kubevip load balancer IP range
 # rke2_loadbalancer_ip_range: 192.168.1.50-192.168.1.100
 
+# Install kubevip cloud provider if rke2_ha_mode_kubevip is true
+rke2_kubevip_cloud_provider_enable: true
+
+# Enable kube-vip to watch Services of type LoadBalancer
+rke2_kubevip_svc_enable: true
+
 # Add additional SANs in k8s API TLS cert
 rke2_additional_sans: []
 

--- a/tasks/kubevip.yml
+++ b/tasks/kubevip.yml
@@ -7,4 +7,17 @@
     group: root
     mode: 0664
   with_fileglob:
-    - "templates/kube-vip/*.j2"
+    - "templates/kube-vip/kube-vip.yml.j2"
+    - "templates/kube-vip/kube-vip-rbac.yml.j2"
+
+- name: Copy kube-vip load balancer manifests to first server
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: "{{ rke2_data_path }}/server/manifests/{{ item | basename | regex_replace('.j2$', '') }}"
+    owner: root
+    group: root
+    mode: 0664
+  with_fileglob:
+    - "templates/kube-vip/kube-vip-cloud-*.j2"
+  when:
+    - rke2_kubevip_cloud_provider_enable | bool

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -35,7 +35,7 @@ spec:
         - name: enableUPNP
           value: "false"
         - name: svc_enable
-          value: "true"
+          value: "{{ rke2_kubevip_svc_enable }}"
         - name: vip_leaderelection
           value: "true"
         - name: vip_leaseduration


### PR DESCRIPTION
# Description

Provides option to enable/disable the deployment of the kube-vip cloud provider manifests for service load balancing allowing deployment of kube-vip AH only if one wants to use another service load balancer such as metallb.

Deployment of kube-vip cloud provider manifests is enabled by default to avoid breaking changes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Deployment tested with new var `rke2_kubevip_cloud_provider_enable` set false.