### PR TITLE
fix: additional image tarballs in airgap mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,23 +40,15 @@ This is a copy of `defaults/main.yml`
 ```yaml
 ---
 
+---
+# Default nodetaints
+node_taints: []
+
 # The node type - server or agent
 rke2_type: server
 
 # Deploy the control plane in HA mode
 rke2_ha_mode: false
-
-# Changes the deploy strategy to install based on local artifacts
-rke2_airgap_mode: false
-
-# Airgap implementation type - download, copy or exists
-# - 'download' will fetch the artifacts on each node,
-# - 'copy' will transfer local files in 'rke2_artifact' to the nodes,
-# - 'exists' assumes 'rke2_artifact' files are already stored in 'rke2_artifact_path'
-rke2_airgap_implementation: download
-
-# Local source path where artifacts are stored
-rke2_airgap_copy_sourcepath: local_artifacts
 
 # Install and configure Keepalived on Server nodes
 # Can be disabled if you are using pre-configured Load Balancer
@@ -66,10 +58,9 @@ rke2_ha_mode_keepalived: true
 # rke2_ha_mode_keepalived needs to be false
 rke2_ha_mode_kubevip: false
 
-
 # Kubernetes API and RKE2 registration IP address. The default Address is the IPv4 of the Server/Master node.
-# In HA mode choose a static IP which will be set as VIP in Keepalived or Kube-VIP.
-# Or if the keepalived and Kube-VIP in this role are disabled, use IP address of your LB.
+# In HA mode choose a static IP which will be set as VIP in keepalived.
+# Or if the keepalived is disabled, use IP address of your LB.
 rke2_api_ip: "{{ hostvars[groups[rke2_servers_group_name].0]['ansible_default_ipv4']['address'] }}"
 
 # optional option for kubevip IP subnet
@@ -123,6 +114,25 @@ rke2_artifact:
   - sha256sum-{{ rke2_architecture }}.txt
   - rke2.linux-{{ rke2_architecture }}.tar.gz
   - rke2-images.linux-{{ rke2_architecture }}.tar.zst
+
+# Changes the deploy strategy to install based on local artifacts
+rke2_airgap_mode: false
+
+# Airgap implementation type - download, copy or exists
+# - 'download' will fetch the artifacts on each node,
+# - 'copy' will transfer local files in 'rke2_artifact' to the nodes,
+# - 'exists' assumes 'rke2_artifact' files are already stored in 'rke2_artifact_path'
+rke2_airgap_implementation: download
+
+# Local source path where artifacts are stored
+rke2_airgap_copy_sourcepath: local_artifacts
+
+# Tarball images for additional components to be copied from rke2_airgap_copy_sourcepath to the nodes
+# (File extensions in the list and on the real files must be retained)
+rke2_airgap_copy_additional_tarballs: []
+
+# Destination for airgap additional images tarballs ( see https://docs.rke2.io/install/airgap/#tarball-method )
+rke2_tarball_images_path: "{{ rke2_data_path }}/rke2/agent/images"
 
 # Architecture to be downloaded, currently there are releases for amd64 and s390x
 rke2_architecture: amd64
@@ -248,7 +258,7 @@ This playbook will deploy RKE2 to a cluster with one server(master) and several 
 
 ```
 
-This playbook will deploy RKE2 to a cluster with one server(master) and several agent(worker) nodes in air-gapped mode. This works from downloading artifacts. When the RKE2 script installs, it will use the artifacts instead of using online resources.
+This playbook will deploy RKE2 to a cluster with one server(master) and several agent(worker) nodes in air-gapped mode. It will use Multus and Calico as CNI.
 
 ```yaml
 - name: Deploy RKE2
@@ -256,12 +266,23 @@ This playbook will deploy RKE2 to a cluster with one server(master) and several 
   become: yes
   vars:
     rke2_airgap_mode: true
+    rke2_airgap_implementation: download
+    rke2_cni:
+      - multus
+      - calico
+    rke2_artifact:
+      - sha256sum-{{ rke2_architecture }}.txt
+      - rke2.linux-{{ rke2_architecture }}.tar.gz
+      - rke2-images.linux-{{ rke2_architecture }}.tar.zst
+    rke2_airgap_copy_additional_tarballs:
+      - rke2-images-multus.linux-{{ rke2_architecture }}
+      - rke2-images-calico.linux-{{ rke2_architecture }}
   roles:
      - role: lablabs.rke2
 
 ```
 
-This playbook will deploy RKE2 to a cluster with HA server(master) control-plane and several  agent(worker) nodes. The server(master) nodes will be tainted so the workload will be distributed only on worker/agent nodes. The role will install also keepalived on the control-plane nodes and setup VIP address where the Kubernetes API will be reachable. it will also download the Kubernetes config file to the local machine.
+This playbook will deploy RKE2 to a cluster with HA server(master) control-plane and several agent(worker) nodes. The server(master) nodes will be tainted so the workload will be distributed only on worker/agent nodes. The role will install also keepalived on the control-plane nodes and setup VIP address where the Kubernetes API will be reachable. it will also download the Kubernetes config file to the local machine.
 
 ```yaml
 - name: Deploy RKE2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,18 +8,6 @@ rke2_type: server
 # Deploy the control plane in HA mode
 rke2_ha_mode: false
 
-# Changes the deploy strategy to install based on local artifacts
-rke2_airgap_mode: false
-
-# Airgap implementation type - download, copy or exists
-# - 'download' will fetch the artifacts on each node,
-# - 'copy' will transfer local files in 'rke2_artifact' to the nodes,
-# - 'exists' assumes 'rke2_artifact' files are already stored in 'rke2_artifact_path'
-rke2_airgap_implementation: download
-
-# Local source path where artifacts are stored
-rke2_airgap_copy_sourcepath: local_artifacts
-
 # Install and configure Keepalived on Server nodes
 # Can be disabled if you are using pre-configured Load Balancer
 rke2_ha_mode_keepalived: true
@@ -27,7 +15,6 @@ rke2_ha_mode_keepalived: true
 # Install and configure kube-vip LB and VIP for cluster
 # rke2_ha_mode_keepalived needs to be false
 rke2_ha_mode_kubevip: false
-
 
 # Kubernetes API and RKE2 registration IP address. The default Address is the IPv4 of the Server/Master node.
 # In HA mode choose a static IP which will be set as VIP in keepalived.
@@ -85,6 +72,25 @@ rke2_artifact:
   - sha256sum-{{ rke2_architecture }}.txt
   - rke2.linux-{{ rke2_architecture }}.tar.gz
   - rke2-images.linux-{{ rke2_architecture }}.tar.zst
+
+# Changes the deploy strategy to install based on local artifacts
+rke2_airgap_mode: false
+
+# Airgap implementation type - download, copy or exists
+# - 'download' will fetch the artifacts on each node,
+# - 'copy' will transfer local files in 'rke2_artifact' to the nodes,
+# - 'exists' assumes 'rke2_artifact' files are already stored in 'rke2_artifact_path'
+rke2_airgap_implementation: download
+
+# Local source path where artifacts are stored
+rke2_airgap_copy_sourcepath: local_artifacts
+
+# Tarball images for additional components to be copied from rke2_airgap_copy_sourcepath to the nodes
+# (File extensions in the list and on the real files must be retained)
+rke2_airgap_copy_additional_tarballs: []
+
+# Destination for airgap additional images tarballs ( see https://docs.rke2.io/install/airgap/#tarball-method )
+rke2_tarball_images_path: "{{ rke2_data_path }}/rke2/agent/images"
 
 # Architecture to be downloaded, currently there are releases for amd64 and s390x
 rke2_architecture: amd64

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -48,6 +48,22 @@
   with_items: "{{ rke2_artifact }}"
   when: rke2_airgap_mode and rke2_airgap_implementation == 'copy'
 
+- name: Airgap mode - additional images tarballs
+  block:
+  - name: Create additional images tarballs folder
+    ansible.builtin.file:
+      path: "{{ rke2_tarball_images_path }}"
+      state: directory
+      mode: 0700
+  - name: Copy additional tarball images RKE2 components
+    ansible.builtin.copy:
+      src: "{{ rke2_airgap_copy_sourcepath }}/{{ item }}"
+      dest: "{{ rke2_tarball_images_path }}/{{ item }}"
+      mode: 0644
+      force: yes
+    with_items: "{{ rke2_airgap_copy_additional_tarballs }}"
+  when: rke2_airgap_mode and ( rke2_airgap_copy_additional_tarballs | length > 0 )
+
 - name: Populate service facts
   ansible.builtin.service_facts:
 


### PR DESCRIPTION
# Description

If Airgap mode is used, copy additional image tarballs to `rke2/agent/images` directory. Fixes #90 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Single node RKE2 in airgap mode with additional image tarballs ( multus, calico )