### PR TITLE
feat: optionally drain node

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ rke2_ha_mode_keepalived: true
 # rke2_ha_mode_keepalived needs to be false
 rke2_ha_mode_kubevip: false
 
-
 # Kubernetes API and RKE2 registration IP address. The default Address is the IPv4 of the Server/Master node.
 # In HA mode choose a static IP which will be set as VIP in Keepalived or Kube-VIP.
 # Or if the keepalived and Kube-VIP in this role are disabled, use IP address of your LB.
@@ -200,6 +199,9 @@ rke2_agents_group_name: workers
 # You could find the flags at https://docs.rke2.io/install/install_options/install_options/#configuring-linux-rke2-agent-nodes
 # rke2_agent_options:
 #   - "option: value"
+
+# Crdon, drain the node which is being upgraded. Uncordon the node once the RKE2 upgraded
+rke2_drain_node_during_upgrade: false
 
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,9 +11,6 @@ rke2_ha_mode: false
 # Changes the deploy strategy to install based on local artifacts
 rke2_airgap_mode: false
 
-# Crdon, drain and uncordon the node during the RKE2 upgrade
-# rke2_graceful_upgrade: false
-
 # Airgap implementation type - download, copy or exists
 # - 'download' will fetch the artifacts on each node,
 # - 'copy' will transfer local files in 'rke2_artifact' to the nodes,
@@ -30,7 +27,6 @@ rke2_ha_mode_keepalived: true
 # Install and configure kube-vip LB and VIP for cluster
 # rke2_ha_mode_keepalived needs to be false
 rke2_ha_mode_kubevip: false
-
 
 # Kubernetes API and RKE2 registration IP address. The default Address is the IPv4 of the Server/Master node.
 # In HA mode choose a static IP which will be set as VIP in keepalived.
@@ -165,3 +161,6 @@ rke2_agents_group_name: workers
 # You could find the flags at https://docs.rke2.io/install/install_options/install_options/#configuring-linux-rke2-agent-nodes
 # rke2_agent_options:
 #   - "option: value"
+
+# Crdon, drain the node which is being upgraded. Uncordon the node once the RKE2 upgraded
+rke2_drain_node_during_upgrade: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,9 @@ rke2_ha_mode: false
 # Changes the deploy strategy to install based on local artifacts
 rke2_airgap_mode: false
 
+# Crdon, drain and uncordon the node during the RKE2 upgrade
+# rke2_graceful_upgrade: false
+
 # Airgap implementation type - download, copy or exists
 # - 'download' will fetch the artifacts on each node,
 # - 'copy' will transfer local files in 'rke2_artifact' to the nodes,

--- a/molecule/ha_cluster/converge.yml
+++ b/molecule/ha_cluster/converge.yml
@@ -3,7 +3,7 @@
   hosts: all
   become: yes
   vars:
-    rke2_version: v1.20.7+rke2r2
+    rke2_version: v1.24.2+rke2r1
     rke2_ha_mode: true
     rke2_server_taint: true
     rke2_api_ip: 192.168.123.100

--- a/tasks/rolling_restart.yml
+++ b/tasks/rolling_restart.yml
@@ -1,6 +1,4 @@
 ---
-- debug:
-    msg: "{{ active_server }} is active"
 
 - name: Cordon and Drain the node {{ inventory_hostname }}
   shell: |

--- a/tasks/rolling_restart.yml
+++ b/tasks/rolling_restart.yml
@@ -1,10 +1,14 @@
 ---
+- debug:
+    msg: "{{ active_server }} is active"
 
-- name: Drain the node {{ inventory_hostname }}
+- name: Cordon and Drain the node {{ inventory_hostname }}
   shell: |
     set -o pipefail
     {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
-    drain "{{ drain_node }}" --ignore-daemonsets --delete-local-data
+    cordon "{{ inventory_hostname }}" && \
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+    drain "{{ inventory_hostname }}" --ignore-daemonsets --delete-local-data
   args:
     executable: /bin/bash
   register: drain
@@ -15,7 +19,7 @@
   changed_when: false
   delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
   run_once: true
-  when: rke2_drain_node
+  when: rke2_drain_node_during_upgrade
 
 - name: Restart RKE2 service on {{ inventory_hostname }}
   service:
@@ -36,3 +40,15 @@
   delay: 15
   delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
   run_once: true
+
+- name: Uncordon the node {{ inventory_hostname }}
+  shell: |
+    set -o pipefail
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+    uncordon "{{ inventory_hostname }}"
+  args:
+    executable: /bin/bash
+  changed_when: false
+  delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
+  run_once: true
+  when: rke2_drain_node_during_upgrade

--- a/tasks/rolling_restart.yml
+++ b/tasks/rolling_restart.yml
@@ -1,4 +1,22 @@
 ---
+
+- name: Drain the node {{ inventory_hostname }}
+  shell: |
+    set -o pipefail
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+    drain "{{ drain_node }}" --ignore-daemonsets --delete-local-data
+  args:
+    executable: /bin/bash
+  register: drain
+  until:
+    - drain.stdout is search('drained')
+  retries: 100
+  delay: 15
+  changed_when: false
+  delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
+  run_once: true
+  when: rke2_drain_node
+
 - name: Restart RKE2 service on {{ inventory_hostname }}
   service:
     name: "rke2-{{ rke2_type }}.service"


### PR DESCRIPTION
# Description

This feature is adding option to cordon, drain the node during the RKE2 upgrade. After upgrade the node is uncordoned. Fixes #75 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Upgrade of 4 node RKE2 cluster
