### PR TITLE
feat: restore etcd from snapshot

### DIFF
--- a/.github/RELEASE_DRAFTER.yml
+++ b/.github/RELEASE_DRAFTER.yml
@@ -12,6 +12,19 @@ categories:
       - 'bug'
   - title: 'Documentation'
     label: 'documentation'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'enhancement'
+      - 'feature'
+  patch:
+    labels:
+      - 'ci'
+      - 'bug'
+  default: patch
 change-template: '- $TITLE, by @$AUTHOR (#$NUMBER)'
 template: |
   # What's changed

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ This is a copy of `defaults/main.yml`
 ```yaml
 ---
 
----
 # Default nodetaints
 node_taints: []
 
@@ -91,7 +90,7 @@ rke2_server_taint: false
 rke2_token: defaultSecret12345
 
 # RKE2 version
-rke2_version: v1.22.6+rke2r1
+rke2_version: v1.24.3+rke2r1
 
 # URL to RKE2 repository
 rke2_channel_url: https://update.rke2.io/v1-release/channels
@@ -132,7 +131,7 @@ rke2_airgap_copy_sourcepath: local_artifacts
 rke2_airgap_copy_additional_tarballs: []
 
 # Destination for airgap additional images tarballs ( see https://docs.rke2.io/install/airgap/#tarball-method )
-rke2_tarball_images_path: "{{ rke2_data_path }}/rke2/agent/images"
+rke2_tarball_images_path: "{{ rke2_data_path }}/agent/images"
 
 # Architecture to be downloaded, currently there are releases for amd64 and s390x
 rke2_architecture: amd64
@@ -169,6 +168,18 @@ rke2_custom_registry_path: templates/registries.yaml.j2
 
 # Path to RKE2 config file template
 rke2_config: templates/config.yaml.j2
+
+# Etcd snapshot source directory
+rke2_etcd_snapshot_source_dir: etcd_snapshots
+
+# Etcd snapshot file name.
+# When the file name is defined, the etcd will be restored on initial deployment Ansible run.
+# The etcd will be restored only during the initial run, so even if you will leave the the file name specified,
+# the etcd will remain untouched during the next runs.
+rke2_etcd_snapshot_file:
+
+# Etcd snapshot location
+rke2_etcd_snapshot_destination_dir: "{{ rke2_data_path }}/server/db/snapshots"
 
 # Override default containerd snapshotter
 rke2_snapshooter: overlayfs

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -90,7 +90,7 @@ rke2_airgap_copy_sourcepath: local_artifacts
 rke2_airgap_copy_additional_tarballs: []
 
 # Destination for airgap additional images tarballs ( see https://docs.rke2.io/install/airgap/#tarball-method )
-rke2_tarball_images_path: "{{ rke2_data_path }}/rke2/agent/images"
+rke2_tarball_images_path: "{{ rke2_data_path }}/agent/images"
 
 # Architecture to be downloaded, currently there are releases for amd64 and s390x
 rke2_architecture: amd64

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -128,6 +128,18 @@ rke2_custom_registry_path: templates/registries.yaml.j2
 # Path to RKE2 config file template
 rke2_config: templates/config.yaml.j2
 
+# Etcd snapshot source directory
+rke2_etcd_snapshot_source_dir: etcd_snapshots
+
+# Etcd snapshot file name.
+# When the file name is defined, the etcd will be restored on initial deployment Ansible run.
+# The etcd will be restored only during the initial run, so even if you will leave the the file name specified,
+# the etcd will remain untouched during the next runs.
+rke2_etcd_snapshot_file:
+
+# Etcd snapshot location
+rke2_etcd_snapshot_destination_dir: "{{ rke2_data_path }}/server/db/snapshots"
+
 # Override default containerd snapshotter
 rke2_snapshooter: overlayfs
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,7 +49,7 @@ rke2_server_taint: false
 rke2_token: defaultSecret12345
 
 # RKE2 version
-rke2_version: v1.22.6+rke2r1
+rke2_version: v1.24.3+rke2r1
 
 # URL to RKE2 repository
 rke2_channel_url: https://update.rke2.io/v1-release/channels

--- a/molecule/ha_cluster/converge.yml
+++ b/molecule/ha_cluster/converge.yml
@@ -3,7 +3,7 @@
   hosts: all
   become: yes
   vars:
-    rke2_version: v1.24.2+rke2r1
+    rke2_version: v1.24.3+rke2r1
     rke2_ha_mode: true
     rke2_server_taint: true
     rke2_api_ip: 192.168.123.100

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -35,6 +35,28 @@
     mode: 0644
   when: rke2_custom_registry_mirrors.0.endpoint | length > 0
 
+- name: Restore etcd
+  block:
+    - name: Create the RKE2 etcd snapshot dir
+      ansible.builtin.file:
+        state: directory
+        path: "{{ rke2_etcd_snapshot_destination_dir }}"
+        recurse: true
+        mode: 0755
+    - name: Copy etcd snapshot file
+      ansible.builtin.copy:
+        src: "{{ rke2_etcd_snapshot_source_dir }}/{{ rke2_etcd_snapshot_file }}"
+        dest: "{{ rke2_etcd_snapshot_destination_dir }}/{{ rke2_etcd_snapshot_file }}"
+        mode: 0644
+        force: true
+    - name: Restore etcd from a snapshot
+      shell: |
+        rke2 server \
+        --cluster-reset \
+        --cluster-reset-restore-path="{{ rke2_etcd_snapshot_destination_dir }}/{{ rke2_etcd_snapshot_file }}" \
+        --token {{ rke2_token }}
+  when: rke2_etcd_snapshot_file
+
 - name: Start RKE2 service on the first server
   ansible.builtin.systemd:
     name: "rke2-server.service"
@@ -51,8 +73,8 @@
 
 - name: Wait for the first server be ready
   ansible.builtin.shell: |
-   set -o pipefail
-   {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep "{{ inventory_hostname }}"
+    set -o pipefail
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep "{{ inventory_hostname }}"
   args:
     executable: /bin/bash
   changed_when: false
@@ -61,6 +83,15 @@
     '" Ready "  in first_server.stdout'
   retries: 40
   delay: 15
+
+- name: Restore etcd - remove old <node>.node-password.rke2 secrets
+  shell: |
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+    delete secret {{ item }}.node-password.rke2 -n kube-system 2>&1 || true
+  args:
+    executable: /bin/bash
+  with_items: "{{ groups[rke2_cluster_group_name] }}"
+  when: rke2_etcd_snapshot_file and inventory_hostname != item
 
 - name: Set an Active Server variable
   ansible.builtin.set_fact:

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -55,7 +55,7 @@
         --cluster-reset \
         --cluster-reset-restore-path="{{ rke2_etcd_snapshot_destination_dir }}/{{ rke2_etcd_snapshot_file }}" \
         --token {{ rke2_token }}
-  when: rke2_etcd_snapshot_file
+  when: rke2_etcd_snapshot_file and ( "rke2-server.service" is not in ansible_facts.services )
 
 - name: Start RKE2 service on the first server
   ansible.builtin.systemd:
@@ -91,7 +91,7 @@
   args:
     executable: /bin/bash
   with_items: "{{ groups[rke2_cluster_group_name] }}"
-  when: rke2_etcd_snapshot_file and inventory_hostname != item
+  when: rke2_etcd_snapshot_file and inventory_hostname != item and  ( "rke2-server.service" is not in ansible_facts.services )
 
 - name: Set an Active Server variable
   ansible.builtin.set_fact:

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -9,12 +9,12 @@
     mode: 0755
 
 - name: Set server taints
-  set_fact:
+  ansible.builtin.set_fact:
     combined_node_taints: "{{ node_taints }} + [ 'CriticalAddonsOnly=true:NoExecute' ]"
   when: rke2_server_taint and rke2_type == 'server'
 
 - name: Set agent taints
-  set_fact:
+  ansible.builtin.set_fact:
     combined_node_taints: "{{ node_taints }}"
   when: rke2_type == 'agent' or not rke2_server_taint
 
@@ -50,7 +50,7 @@
         mode: 0644
         force: true
     - name: Restore etcd from a snapshot
-      shell: |
+      ansible.builtin.shell: |
         rke2 server \
         --cluster-reset \
         --cluster-reset-restore-path="{{ rke2_etcd_snapshot_destination_dir }}/{{ rke2_etcd_snapshot_file }}" \
@@ -85,7 +85,7 @@
   delay: 15
 
 - name: Restore etcd - remove old <node>.node-password.rke2 secrets
-  shell: |
+  ansible.builtin.shell: |
     {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
     delete secret {{ item }}.node-password.rke2 -n kube-system 2>&1 || true
   args:

--- a/tasks/rolling_restart.yml
+++ b/tasks/rolling_restart.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Cordon and Drain the node {{ inventory_hostname }}
-  shell: |
+  ansible.builtin.shell: |
     set -o pipefail
     {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
     cordon "{{ inventory_hostname }}" && \
@@ -20,7 +20,7 @@
   when: rke2_drain_node_during_upgrade
 
 - name: Restart RKE2 service on {{ inventory_hostname }}
-  service:
+  ansible.builtin.service:
     name: "rke2-{{ rke2_type }}.service"
     state: restarted
 
@@ -40,7 +40,7 @@
   run_once: true
 
 - name: Uncordon the node {{ inventory_hostname }}
-  shell: |
+  ansible.builtin.shell: |
     set -o pipefail
     {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
     uncordon "{{ inventory_hostname }}"

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -35,8 +35,8 @@
 
 - name: Wait for the RKE2 server to be ready
   ansible.builtin.shell: |
-   set -o pipefail
-   {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep "{{ inventory_hostname }}"
+    set -o pipefail
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep "{{ inventory_hostname }}"
   args:
     executable: /bin/bash
   changed_when: false


### PR DESCRIPTION
# Description

This PR is
- adding an option to restore etcd from a snapshot during the RKE2 deployment
- fixed default path to additional tarballs used during air-gaped deployment
- bumped default RKE2 version 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Tested manually on two node RKE2 cluster (one server and one agent)
