### PR TITLE
increase timeout for download of rke2 artifacts and checksum

### DIFF
--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -30,12 +30,14 @@
       dest: "{{ rke2_artifact_path }}/sha256sum-{{ rke2_architecture }}.txt"
       force: yes
       mode: 0644
+      timeout: 30
   - name: Download RKE2 artifacts and compare with checksums
     ansible.builtin.get_url:
       url: "{{ rke2_artifact_url }}/{{ rke2_version }}/{{ item }}"
       dest: "{{ rke2_artifact_path }}/{{ item }}"
       mode: 0644
       checksum: "sha256:{{ rke2_artifact_url }}{{ rke2_version }}/sha256sum-{{ rke2_architecture }}.txt"
+      timeout: 30
     with_items: "{{ rke2_artifact | reject('search','sha256sum') | list }}"
   when: rke2_airgap_mode and rke2_airgap_implementation == 'download'
 


### PR DESCRIPTION
# Description
Timeout of downloads of rke2 artifacts and checksum was increased. Default timeout is 10 seconds which caused problems in our environment.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)
