### PR TITLE
docs: add troubleshooting section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,15 @@ This playbook will deploy RKE2 to a cluster with HA server(master) control-plane
 
 ```
 
+## Troubleshooting
+
+### Playbook stuck while starting the RKE2 service on agents
+
+If the playbook starts to hang at the `Start RKE2 service on the rest of the nodes` task and then fails at the `Wait for remaining nodes to be ready` task, you probably have some limitations on you nodes' network.
+
+Please check the required *Inbound Rules for RKE2 Server Nodes* at the following link: <https://docs.rke2.io/install/requirements/#networking>.
+
+
 ## License
 
 MIT


### PR DESCRIPTION
# Description

During the excution of the playbook, especially with machine not managed directly by you, the playbook can hang without prompting any meaningful information while starting the RKE2 agent service.

This could be related to network policies.

This couple of documentation lines could save some debugging time.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)
