### PR TITLE
Add data-dir option to config.yaml.j2

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -3,6 +3,7 @@
 server: https://{{ rke2_api_ip }}:9345
 {% endif %}
 token: {{ rke2_token }}
+data-dir: {{ rke2_data_path }}
 {% if inventory_hostname in groups[rke2_servers_group_name] %}
 cni: {{ rke2_cni }}
 tls-san:


### PR DESCRIPTION
data-dir option was missing in config.yaml template

# Description
<!---

--->
The data-dir option was missing in config.yaml.j2 template and so the role always used the standard directory /var/lib/rancher/rke2

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---

--->
Tested in ansible-playbook run?
Sorry for inconvenience, first PR. :-)
