### PR TITLE
feat: update kube-vip to v0.5.0

### DIFF
--- a/templates/kube-vip/kube-vip-cloud-controller.yml.j2
+++ b/templates/kube-vip/kube-vip-cloud-controller.yml.j2
@@ -58,7 +58,7 @@ spec:
       - command:
         - /kube-vip-cloud-provider
         - --leader-elect-resource-name=kube-vip-cloud-controller
-        image: kubevip/kube-vip-cloud-provider:0.1
+        image: ghcr.io/kube-vip/kube-vip-cloud-provider:v0.0.3
         name: kube-vip-cloud-provider
         imagePullPolicy: Always
         resources: {}

--- a/templates/kube-vip/kube-vip-rbac.yml.j2
+++ b/templates/kube-vip/kube-vip-rbac.yml.j2
@@ -12,7 +12,7 @@ metadata:
   name: system:kube-vip-role
 rules:
   - apiGroups: [""]
-    resources: ["services", "services/status", "nodes"]
+    resources: ["services", "services/status", "nodes", "endpoints"]
     verbs: ["list","get","watch", "update"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -2,18 +2,32 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: kube-vip-ds
+    app.kubernetes.io/version: v0.5.0
   name: kube-vip-ds
   namespace: kube-system
 spec:
   selector:
     matchLabels:
-      name: kube-vip-ds
+      app.kubernetes.io/name: kube-vip-ds
   template:
     metadata:
       creationTimestamp: null
       labels:
-        name: kube-vip-ds
+        app.kubernetes.io/name: kube-vip-ds
+        app.kubernetes.io/version: v0.5.0
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
       containers:
       - args:
         - manager
@@ -36,6 +50,8 @@ spec:
           value: "false"
         - name: svc_enable
           value: "{{ rke2_kubevip_svc_enable }}"
+        - name: svc_election
+          value: "true"
         - name: vip_leaderelection
           value: "true"
         - name: vip_leaseduration
@@ -46,7 +62,9 @@ spec:
           value: "1"
         - name: address
           value: "{{ rke2_api_ip }}"
-        image: ghcr.io/kube-vip/kube-vip:v0.4.0
+        - name: prometheus_server
+          value: :2112
+        image: ghcr.io/kube-vip/kube-vip:v0.5.0
         imagePullPolicy: Always
         name: kube-vip
         resources: {}
@@ -55,7 +73,6 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
-            - SYS_TIME
       hostNetwork: true
       serviceAccountName: kube-vip
       tolerations:


### PR DESCRIPTION
# Description

Bump up kube-vip to version v0.5.0 and kube-vip cloud provider to v0.0.3.

- https://github.com/kube-vip/kube-vip/releases/tag/v0.5.0
- https://github.com/kube-vip/kube-vip-cloud-provider/releases/tag/v0.0.3

kube-vip is configured with the new "[leader election per service](https://kube-vip.io/docs/usage/kubernetes-services/#load-balancing-load-balancers-when-using-arp-mode-yes-you-read-that-correctly-kube-vip-v050)" feature enabled.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Deployment to cluster with 3 masters and 1 worker, with following settings:

```
        rke2_ha_mode: true
        rke2_ha_mode_keepalived: false
        rke2_ha_mode_kubevip: true
        rke2_kubevip_cloud_provider_enable: true
        rke2_kubevip_svc_enable: true
```
