### PR TITLE
Fix bug restart rke2 when config file in /etc/rancher/rke2/config.yam…

### DIFF
--- a/tasks/change_config.yml
+++ b/tasks/change_config.yml
@@ -1,0 +1,38 @@
+---
+- name: Restart RKE2 service on {{ inventory_hostname }}
+  ansible.builtin.service:
+    name: "rke2-{{ rke2_type }}.service"
+    state: restarted
+
+- name: Wait for all nodes to be ready again
+  ansible.builtin.shell: |
+    set -o pipefail
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep " Ready" | wc -l
+  args:
+    executable: /bin/bash
+  changed_when: false
+  register: all_ready_nodes
+  until:
+    - groups[rke2_cluster_group_name] | length == all_ready_nodes.stdout | int
+  retries: 100
+  delay: 15
+  delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
+  run_once: true
+
+- name: Wait for all pods to be ready again
+  ansible.builtin.shell: |
+    set -o pipefail
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get pods -A --field-selector=metadata.namespace!=kube-system | grep -iE "crash|error|init|terminating" | wc -l
+  args:
+    executable: /bin/bash
+  failed_when: "all_pods_ready.rc not in [ 0, 1 ]"
+  changed_when: false
+  register: all_pods_ready
+  until:
+    '"0" in all_pods_ready.stdout'
+  retries: 100
+  delay: 15
+  delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
+  run_once: true
+  when: rke2_wait_for_all_pods_to_be_ready
+  

--- a/tasks/change_config.yml
+++ b/tasks/change_config.yml
@@ -35,4 +35,3 @@
   delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
   run_once: true
   when: rke2_wait_for_all_pods_to_be_ready
-  

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -25,6 +25,7 @@
     owner: root
     group: root
     mode: 0644
+  register: config_file_is_changed
 
 - name: Copy Containerd Registry Configuration file
   ansible.builtin.template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,10 +53,10 @@
   with_items: "{{ groups[rke2_cluster_group_name] }}"
   loop_control:
     loop_var: _host_item
-  when: 
-  - rke2_drain_node_during_upgrade | bool == false
+  when:
+  - rke2_drain_node_during_upgrade | bool
   - hostvars[_host_item].inventory_hostname == inventory_hostname
-  - config_file_is_changed.changed == true
+  - config_file_is_changed.changed
 
 - name: Final steps
   ansible.builtin.include_tasks: summary.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,7 @@
   loop_control:
     loop_var: _host_item
   when:
-  - rke2_drain_node_during_upgrade | bool
+  - not rke2_drain_node_during_upgrade
   - hostvars[_host_item].inventory_hostname == inventory_hostname
   - config_file_is_changed.changed
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,5 +43,15 @@
     loop_var: _host_item
   when: ( hostvars[_host_item].inventory_hostname == inventory_hostname ) and installed_rke2_version.stdout is defined and rke2_version != ( installed_rke2_version.stdout | default({}) )
 
+- name: Restart service when config file is changed
+  ansible.builtin.include_tasks: change_config.yml
+  with_items: "{{ groups[rke2_cluster_group_name] }}"
+  loop_control:
+    loop_var: _host_item
+  when: 
+  - rke2_drain_node_during_upgrade | bool == false
+  - hostvars[_host_item].inventory_hostname == inventory_hostname
+  - config_file_is_changed.changed == true
+
 - name: Final steps
   ansible.builtin.include_tasks: summary.yml

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -25,6 +25,7 @@
     owner: root
     group: root
     mode: 0644
+  register: config_file_is_changed
 
 - name: Copy Containerd Registry Configuration file
   ansible.builtin.template:

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -15,6 +15,7 @@
     owner: root
     group: root
     mode: 0644
+  register: config_file_is_changed
 
 - name: Copy Containerd Registry Configuration file
   ansible.builtin.template:


### PR DESCRIPTION
…l is changed (rke2_server_options and rke2_agent_options)

# Description

Fix bug restart rke2 when config file in /etc/rancher/rke2/config.yaml is changed with rke2_server_options and rke2_agent_options environment in default/main.yaml

<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
**Tested**. I have tested been with this new feature
- High Availability ( 03 masters and 02 workers)
- Standalone ( 01 master and 02 worker)
<!---

Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
