### PR TITLE
[Bug] Ingress controller app was pending because worker nodes have been tainted.

### DIFF
--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -13,11 +13,6 @@
     combined_node_taints: "{{ node_taints + [ 'CriticalAddonsOnly=true:NoExecute' ] }}"
   when: rke2_server_taint and rke2_type == 'server'
 
-- name: Set agent taints
-  ansible.builtin.set_fact:
-    combined_node_taints: "{{ node_taints }}"
-  when: rke2_type == 'agent' or not rke2_server_taint
-
 - name: Copy rke2 config
   ansible.builtin.template:
     src: "{{ rke2_config }}"

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -13,11 +13,6 @@
     combined_node_taints: "{{ node_taints + [ 'CriticalAddonsOnly=true:NoExecute' ] }}"
   when: rke2_server_taint and rke2_type == 'server'
 
-- name: Set agent taints
-  set_fact:
-    combined_node_taints: "{{ node_taints }}"
-  when: rke2_type == 'agent' or not rke2_server_taint
-
 - name: Copy RKE2 config
   ansible.builtin.template:
     src: "{{ rke2_config }}"


### PR DESCRIPTION
# Description
Hi @MonolithProjects.
When I added key:value in node_taints["key1:value1","key2:value2"] variable and set rke2_server_taint: true, the Ingress controller app was pending because worker nodes have been tainted.
As I see it that task is always true with "when: rke2_type == 'agent' or not rke2_server_taint" condition if we add one or more values in node_taints[] variable. So, in my opinion, we should choose a suitable condition or remove that task. Because most worker nodes will not set taints

<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Tested. I have tested been with this bug on High Availability ( 03 masters and 02 workers)

<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
