### PR TITLE
Fill in the missing "/" when download RKE2 artifacts

### DIFF
--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -36,7 +36,7 @@
       url: "{{ rke2_artifact_url }}/{{ rke2_version }}/{{ item }}"
       dest: "{{ rke2_artifact_path }}/{{ item }}"
       mode: 0644
-      checksum: "sha256:{{ rke2_artifact_url }}{{ rke2_version }}/sha256sum-{{ rke2_architecture }}.txt"
+      checksum: "sha256:{{ rke2_artifact_url }}/{{ rke2_version }}/sha256sum-{{ rke2_architecture }}.txt"
       timeout: 30
     with_items: "{{ rke2_artifact | reject('search','sha256sum') | list }}"
   when: rke2_airgap_mode and rke2_airgap_implementation == 'download'


### PR DESCRIPTION
# Description


<!---
Please include a summary of the change and which issue is fixed.
--->

When I download RKE2, I use a file server to download instead of from Github
This uses the rke2_artifact_url parameter, like this
rke2_artifact_url: https://xxxxx/repository/rke2-release

But the final download url used is
https://xxxxx/repository/rke2-releasev1.25.4+rke2r1/xxxxxxxxxxxx
Obviously it's missing a "/"

This should be caused by the lack of a "/" in the task

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
