### PR TITLE
Flush handlers after configuring sysctl

### DIFF
--- a/tasks/cis.yml
+++ b/tasks/cis.yml
@@ -20,3 +20,6 @@
     mode: 0600
     remote_src: true
   notify: restart systemd-sysctl
+
+- name: Flush handlers
+  ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
# Description

Server/agent does not start when cis profile is set on new nodes. sysctl's need to be applied (systemd-sysctl restarted) before starting the server/agent. Play will hang on "Wait for remaining nodes to be ready". The server/agent complains about the following:

```
level=fatal msg="invalid kernel parameter value vm.overcommit_memory=0 - expected 1\ninvalid kernel parameter value kernel.panic=0 - expected 10\ninvalid kernel parameter value kernel.panic_on_oops=0 - expected 1\n"
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Tested adding a new (freshly installed ubuntu 22.04) server and agent to an existing rke2 cluster with this change (and cis-1.23 profile set). Without flushing the handlers, the play hang on waiting for all nodes to be ready as the new nodes rke2 service was not starting. After the change, the rke2 service starts and the play completed succesfully. 