### PR TITLE
Remove option taints because it affects core services and other apps in k8s

### DIFF
--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -10,7 +10,7 @@
 
 - name: Set server taints
   ansible.builtin.set_fact:
-    combined_node_taints: "{{ node_taints + [ 'CriticalAddonsOnly=true:NoExecute' ] }}"
+    combined_node_taints: "{{ node_taints }}"
   when: rke2_server_taint and rke2_type == 'server'
 
 - name: Set agent taints

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -10,7 +10,7 @@
 
 - name: Set server taints
   set_fact:
-    combined_node_taints: "{{ node_taints + [ 'CriticalAddonsOnly=true:NoExecute' ] }}"
+    combined_node_taints: "{{ node_taints }}"
   when: rke2_server_taint and rke2_type == 'server'
 
 - name: Set agent taints


### PR DESCRIPTION
# Description
Hi @MonolithProjects

In my opinion, when the "CriticalAddonsOnly" taint was added, it was not suitable for almost situation. Because the rke2 tool recommends only its as an option. If this taint was added, it also affect some core services such as the ingress controller and metrics server.
 
Reference: https://docs.rke2.io/install/ha#2a-optional-consider-server-node-taints

In addition, when I have been deployed rancher-vsphere-cpi which was pending because it didn't find a suitable taint (CriticalAddonsOnly)

Reference: https://github.com/rancher/charts/blob/dev-v2.7/charts/rancher-vsphere-cpi/101.1.0%2Bup1.4.1/templates/daemonset.yaml

So I think that you can remove it or add a more popular taint with other apps.

Thank you.

<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Tested. I have tested been with this breaking change
- High Availability ( 03 masters and 02 workers)
- Standalone ( 01 master and 02 worker)
