### PR TITLE
Fix error when config_file_is_change is not defined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
   when:
   - not rke2_drain_node_during_upgrade
   - hostvars[_host_item].inventory_hostname == inventory_hostname
-  - config_file_is_changed.changed
+  - config_file_is_changed is defined and config_file_is_changed.changed
 
 - name: Final steps
   ansible.builtin.include_tasks: summary.yml


### PR DESCRIPTION
# Description

When re-executing a playbook with this role, RKE2 cluster is running, and no change is requested, an error occurs because `config_file_is_change` is not defined in `Restart service when config file is changed` task.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
- Create an inventory with only one server
- Execute a playbook with this role to deploy the cluster
- Execute the same playbook again