### PR TITLE
feat: support setting agent token

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,24 @@ This playbook will deploy RKE2 to a cluster with HA server(master) control-plane
 
 ```
 
+## Having separate token for agent nodes
+
+As per [server configuration documentation](https://docs.rke2.io/reference/server_config) it is possible to define an agent token, which will be used by agent nodes to connect to cluster, giving them less access to cluster than server nodes have.
+Following modifications to above configuration would be necessary:
+- remove `rke2_token` from global vars
+- add to `group_vars/masters.yml`:
+```yaml
+rke2_token: defaultSecret12345
+rke2_agent_token: agentSecret54321
+```
+- add to `group_vars/workers.yml`:
+```yaml
+rke2_token: agentSecret54321
+```
+
+While changing server token is problematic, agent token can be rotated at will, as long as servers and agents have the same value and the services
+(`rke2-server` and `rke2-agent`, as appropriate) have been restarted to make sure the processes use the new value.
+
 ## Troubleshooting
 
 ### Playbook stuck while starting the RKE2 service on agents

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -2,6 +2,9 @@
 {% if active_server is defined %}
 server: https://{{ rke2_api_ip }}:9345
 {% endif %}
+{% if rke2_agent_token is defined %}
+agent-token: {{ rke2_agent_token }}
+{% endif %}
 token: {{ rke2_token }}
 data-dir: {{ rke2_data_path }}
 {% if inventory_hostname in groups[rke2_servers_group_name] %}


### PR DESCRIPTION
Adds support for having a separate agent token to connect agent nodes to cluster.

# Description

As described in [server configuration documentation](https://docs.rke2.io/reference/server_config), it is possible to define a separate token for agent nodes to use, that does not expose all the etcd secrets like server token does.

This adds support for setting a new variable that will set said token.

Resolves #131 
<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

I've used a local copy with this set when setting up a cluster for evaluation.