### PR TITLE
feat: add ability for RKE2 server to listen on private IP address

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,13 +18,16 @@ rke2_ha_mode_kubevip: false
 # Or if the keepalived is disabled, use IP address of your LB.
 rke2_api_ip: "{{ hostvars[groups[rke2_servers_group_name].0]['ansible_default_ipv4']['address'] }}"
 
+# optional option for RKE2 Server to listen on a private IP address on port 9345
+# rke2_api_private_ip:
+
 # optional option for kubevip IP subnet
 # rke2_api_cidr: 24
 
 # optional option for kubevip
 # rke2_interface: eth0
 
-# optiononal option for kubevip load balancer IP range
+# optional option for kubevip load balancer IP range
 # rke2_loadbalancer_ip_range: 192.168.1.50-192.168.1.100
 
 # Install kubevip cloud provider if rke2_ha_mode_kubevip is true

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -1,6 +1,10 @@
 
 {% if active_server is defined %}
+{% if rke2_api_private_ip is defined %}
+server: https://{{ rke2_api_private_ip }}:9345
+{% else %}
 server: https://{{ rke2_api_ip }}:9345
+{% endif %}
 {% endif %}
 {% if rke2_agent_token is defined %}
 agent-token: {{ rke2_agent_token }}


### PR DESCRIPTION
# Description
Adds the ability to configure the RKE2 server to listen on a private IP address on port 9345.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Ran an Ansible Run with `rke2_api_ip` and the new `rke2_api_private_ip` param. The `config.yaml` uses the `rke2_api_private_ip` when it is provided and the server value becomes `<private_ip_addres>:9345` while everything else is unchanged. If `rke2_api_private_ip` is not provided, then nothing changes.
