### PR TITLE
Provide option to disable kube-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,11 @@ rke2_install_script_dir: /var/tmp
 rke2_channel: stable
 
 # Do not deploy packaged components and delete any deployed components
-# Valid items: rke2-canal, rke2-coredns, rke2-ingress-nginx, rke2-kube-proxy, rke2-metrics-server
+# Valid items: rke2-canal, rke2-coredns, rke2-ingress-nginx, rke2-metrics-server
 rke2_disable:
+
+# Option to disable kube-proxy
+# disable_kube_proxy: true
 
 # Path to custom manifests deployed during the RKE2 installation
 # It is possible to use Jinja2 templating in the manifests
@@ -196,7 +199,6 @@ rke2_etcd_snapshot_destination_dir: "{{ rke2_data_path }}/server/db/snapshots"
   # endpoint_ca: "" # optional. Can skip if using defaults
   # region: "" # optional - defaults to us-east-1
   # folder: "" # optional - defaults to top level of bucket
-
 # Override default containerd snapshotter
 rke2_snapshooter: overlayfs
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,8 +103,11 @@ rke2_install_script_dir: /var/tmp
 rke2_channel: stable
 
 # Do not deploy packaged components and delete any deployed components
-# Valid items: rke2-canal, rke2-coredns, rke2-ingress-nginx, rke2-kube-proxy, rke2-metrics-server
+# Valid items: rke2-canal, rke2-coredns, rke2-ingress-nginx, rke2-metrics-server
 rke2_disable:
+
+# Option to disable kube-proxy
+# disable_kube_proxy: true
 
 # Path to custom manifests deployed during the RKE2 installation
 # It is possible to use Jinja2 templating in the manifests

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -36,6 +36,9 @@ node-label:
 {% endif %}
 snapshotter: {{ rke2_snapshooter }}
 node-name: {{ inventory_hostname }}
+{% if ( disable_kube_proxy | bool ) %}
+disable-kube-proxy: true
+{% endif %}
 {% if 'cis' in rke2_cis_profile %}
 profile: {{ rke2_cis_profile }}
 {%endif%}


### PR DESCRIPTION
# Description

RKE2 has changed the method to disable kube-proxy. It is no longer sufficient to list rke2-kube-proxy in the rke_disable list. Instead, kube-proxy must be explicitly disabled with a special config flag.

References: 
1. https://docs.rke2.io/advanced?_highlight=disable#disabling-server-charts
2. https://github.com/rancher/rke2/issues/2728

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Deployed a cluster with `disable_kube_proxy` set to `true` - the kube-proxy pods no longer come up in `kube-system` namespace. 

