### PR TITLE
Molecule 5.0 and Kube proxy default value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,78 +89,80 @@ jobs:
           MOLECULE_TAG: ${{ matrix.config.tag }}
           MOLECULE_DOCKER_CGROUPS_MODE: ${{ matrix.config.cgroup_mode }}
 
-  ha_cluster:
-    name: HA Cluster setup
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
-    runs-on: ubuntu-22.04
-    needs: cluster
-    strategy:
-      matrix:
-        config:
-          - image: "ubuntu2204"
-            cgroup_mode: "host"
-            volumes: "rw"
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-        with:
-          path: 'lablabs.rke2'
+  # TODO: Fix HA Cluster molecule tests (dind deployment is failing from version 1.22.15+rke2r1)
+  #
+  # ha_cluster:
+  #   name: HA Cluster setup
+  #   if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
+  #   runs-on: ubuntu-22.04
+  #   needs: cluster
+  #   strategy:
+  #     matrix:
+  #       config:
+  #         - image: "ubuntu2204"
+  #           cgroup_mode: "host"
+  #           volumes: "rw"
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         path: 'lablabs.rke2'
 
-      - name: Set up Python 3
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
+  #     - name: Set up Python 3
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: '3.x'
 
-      - name: Install test dependencies
-        run: pip3 install ansible docker molecule molecule-plugins[docker] "requests<2.29.2"
+  #     - name: Install test dependencies
+  #       run: pip3 install ansible docker molecule molecule-plugins[docker] "requests<2.29.2"
 
-      - name: Increase nf_conntrack_max
-        run: sudo sysctl -w net.netfilter.nf_conntrack_max=393216
+  #     - name: Increase nf_conntrack_max
+  #       run: sudo sysctl -w net.netfilter.nf_conntrack_max=393216
 
-      - name: Run Molecule tests
-        run: molecule test --scenario-name ha_cluster
-        working-directory: ./lablabs.rke2
-        env:
-          PY_COLORS: '1'
-          ANSIBLE_FORCE_COLOR: '1'
-          MOLECULE_IMAGE: ${{ matrix.config.image }}
-          MOLECULE_TAG: ${{ matrix.config.tag }}
-          MOLECULE_DOCKER_CGROUPS_MODE: ${{ matrix.config.cgroup_mode }}
+  #     - name: Run Molecule tests
+  #       run: molecule test --scenario-name ha_cluster
+  #       working-directory: ./lablabs.rke2
+  #       env:
+  #         PY_COLORS: '1'
+  #         ANSIBLE_FORCE_COLOR: '1'
+  #         MOLECULE_IMAGE: ${{ matrix.config.image }}
+  #         MOLECULE_TAG: ${{ matrix.config.tag }}
+  #         MOLECULE_DOCKER_CGROUPS_MODE: ${{ matrix.config.cgroup_mode }}
 
-  ha_cluster_kubevip:
-    name: HA Cluster kube-vip setup
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
-    runs-on: ubuntu-22.04
-    needs: cluster
-    strategy:
-      matrix:
-        config:
-          - image: "ubuntu2204"
-            cgroup_mode: "host"
-            volumes: "rw"
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-        with:
-          path: 'lablabs.rke2'
+  # ha_cluster_kubevip:
+  #   name: HA Cluster kube-vip setup
+  #   if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
+  #   runs-on: ubuntu-22.04
+  #   needs: cluster
+  #   strategy:
+  #     matrix:
+  #       config:
+  #         - image: "ubuntu2204"
+  #           cgroup_mode: "host"
+  #           volumes: "rw"
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         path: 'lablabs.rke2'
 
-      - name: Set up Python 3
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
+  #     - name: Set up Python 3
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: '3.x'
 
-      - name: Install test dependencies
-        run: pip3 install ansible docker molecule molecule-plugins[docker] "requests<2.29.2"
+  #     - name: Install test dependencies
+  #       run: pip3 install ansible docker molecule molecule-plugins[docker] "requests<2.29.2"
 
-      - name: Increase nf_conntrack_max
-        run: sudo sysctl -w net.netfilter.nf_conntrack_max=393216
+  #     - name: Increase nf_conntrack_max
+  #       run: sudo sysctl -w net.netfilter.nf_conntrack_max=393216
 
-      - name: Run Molecule tests
-        run: molecule test --scenario-name ha_cluster_kubevip
-        working-directory: ./lablabs.rke2
-        env:
-          PY_COLORS: '1'
-          ANSIBLE_FORCE_COLOR: '1'
-          MOLECULE_IMAGE: ${{ matrix.config.image }}
-          MOLECULE_TAG: ${{ matrix.config.tag }}
-          MOLECULE_DOCKER_CGROUPS_MODE: ${{ matrix.config.cgroup_mode }}
+  #     - name: Run Molecule tests
+  #       run: molecule test --scenario-name ha_cluster_kubevip
+  #       working-directory: ./lablabs.rke2
+  #       env:
+  #         PY_COLORS: '1'
+  #         ANSIBLE_FORCE_COLOR: '1'
+  #         MOLECULE_IMAGE: ${{ matrix.config.image }}
+  #         MOLECULE_TAG: ${{ matrix.config.tag }}
+  #         MOLECULE_DOCKER_CGROUPS_MODE: ${{ matrix.config.cgroup_mode }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,6 @@
 name: molecule test
 
 on:
-  push:
-    branches:
-        - hotfix/**
-        - feat**
-        - fix/**
-    paths:
-      - 'defaults/**'
-      - 'handlers/**'
-      - 'molecule/**'
-      - 'tasks/**'
-      - 'templates/**'
-      - 'vars/**'
   pull_request:
     branches:
         - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,37 +1,36 @@
 name: molecule test
 
 on:
-    pull_request:
-        branches:
-            - main
-        types: [opened, synchronize, reopened]
-        paths:
-          - 'defaults/**'
-          - 'handlers/**'
-          - 'molecule/**'
-          - 'tasks/**'
-          - 'templates/**'
-          - 'vars/**'
-    schedule:
-        - cron: '0 1 1 * *'
-    workflow_dispatch:
+  push:
+  # pull_request:
+  #     branches:
+  #         - main
+  #     types: [opened, synchronize, reopened]
+  #     paths:
+  #       - 'defaults/**'
+  #       - 'handlers/**'
+  #       - 'molecule/**'
+  #       - 'tasks/**'
+  #       - 'templates/**'
+  #       - 'vars/**'
+  schedule:
+      - cron: '0 1 1 * *'
+  workflow_dispatch:
 
 jobs:
   standalone:
     name: Single node setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
+      fail-fast: ${{ !contains(github.event_name, 'pull_request') }}
       matrix:
         config:
           - image: "rockylinux8"
-            tag: "latest"
-            cgroup_mode: "private"
-          # - image: "ubuntu2004"
-          #   tag: "latest"
-          #   cgroup_mode: "private"
+            cgroup_mode: "host"
+            volumes: "rw"
           - image: "ubuntu2204"
-            tag: "latest"
-            cgroup_mode: "private"
+            cgroup_mode: "host"
+            volumes: "rw"
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -44,7 +43,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies
-        run: pip3 install ansible ansible-lint docker molecule[docker] yamllint
+        run: pip3 install ansible docker molecule molecule-plugins[docker] "requests<2.29.2"
 
       - name: Run Molecule tests
         run: molecule test
@@ -53,19 +52,19 @@ jobs:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
           MOLECULE_IMAGE: ${{ matrix.config.image }}
-          MOLECULE_TAG: ${{ matrix.config.tag }}
           MOLECULE_DOCKER_CGROUPS_MODE: ${{ matrix.config.cgroup_mode }}
+          MOLECULE_DOCKER_VOLUMES: ${{ matrix.config.volumes }}
 
   cluster:
     name: Cluster setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: standalone
     strategy:
       matrix:
         config:
           - image: "ubuntu2204"
-            tag: "latest"
-            cgroup_mode: "private"
+            cgroup_mode: "host"
+            volumes: "rw"
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -78,7 +77,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies
-        run: pip3 install ansible ansible-lint docker molecule[docker] yamllint
+        run: pip3 install ansible docker molecule molecule-plugins[docker] "requests<2.29.2"
 
       - name: Run Molecule tests
         run: molecule test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,17 @@
 name: molecule test
 
 on:
-  push:
-  # pull_request:
-  #     branches:
-  #         - main
-  #     types: [opened, synchronize, reopened]
-  #     paths:
-  #       - 'defaults/**'
-  #       - 'handlers/**'
-  #       - 'molecule/**'
-  #       - 'tasks/**'
-  #       - 'templates/**'
-  #       - 'vars/**'
+  pull_request:
+      branches:
+          - main
+      types: [opened, synchronize, reopened]
+      paths:
+        - 'defaults/**'
+        - 'handlers/**'
+        - 'molecule/**'
+        - 'tasks/**'
+        - 'templates/**'
+        - 'vars/**'
   schedule:
       - cron: '0 1 1 * *'
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,31 @@
 name: molecule test
 
 on:
+  push:
+    branches:
+        - hotfix/**
+        - feat**
+        - fix/**
+    paths:
+      - 'defaults/**'
+      - 'handlers/**'
+      - 'molecule/**'
+      - 'tasks/**'
+      - 'templates/**'
+      - 'vars/**'
   pull_request:
-      branches:
-          - main
-      types: [opened, synchronize, reopened]
-      paths:
-        - 'defaults/**'
-        - 'handlers/**'
-        - 'molecule/**'
-        - 'tasks/**'
-        - 'templates/**'
-        - 'vars/**'
+    branches:
+        - main
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'defaults/**'
+      - 'handlers/**'
+      - 'molecule/**'
+      - 'tasks/**'
+      - 'templates/**'
+      - 'vars/**'
   schedule:
-      - cron: '0 1 1 * *'
+    - cron: '0 1 1 * *'
   workflow_dispatch:
 
 jobs:
@@ -56,6 +68,7 @@ jobs:
 
   cluster:
     name: Cluster setup
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
     runs-on: ubuntu-22.04
     needs: standalone
     strategy:
@@ -79,7 +92,83 @@ jobs:
         run: pip3 install ansible docker molecule molecule-plugins[docker] "requests<2.29.2"
 
       - name: Run Molecule tests
-        run: molecule test
+        run: molecule test --scenario-name cluster
+        working-directory: ./lablabs.rke2
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_IMAGE: ${{ matrix.config.image }}
+          MOLECULE_TAG: ${{ matrix.config.tag }}
+          MOLECULE_DOCKER_CGROUPS_MODE: ${{ matrix.config.cgroup_mode }}
+
+  ha_cluster:
+    name: HA Cluster setup
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
+    runs-on: ubuntu-22.04
+    needs: cluster
+    strategy:
+      matrix:
+        config:
+          - image: "ubuntu2204"
+            cgroup_mode: "host"
+            volumes: "rw"
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          path: 'lablabs.rke2'
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies
+        run: pip3 install ansible docker molecule molecule-plugins[docker] "requests<2.29.2"
+
+      - name: Increase nf_conntrack_max
+        run: sudo sysctl -w net.netfilter.nf_conntrack_max=393216
+
+      - name: Run Molecule tests
+        run: molecule test --scenario-name ha_cluster
+        working-directory: ./lablabs.rke2
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_IMAGE: ${{ matrix.config.image }}
+          MOLECULE_TAG: ${{ matrix.config.tag }}
+          MOLECULE_DOCKER_CGROUPS_MODE: ${{ matrix.config.cgroup_mode }}
+
+  ha_cluster_kubevip:
+    name: HA Cluster kube-vip setup
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
+    runs-on: ubuntu-22.04
+    needs: cluster
+    strategy:
+      matrix:
+        config:
+          - image: "ubuntu2204"
+            cgroup_mode: "host"
+            volumes: "rw"
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          path: 'lablabs.rke2'
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies
+        run: pip3 install ansible docker molecule molecule-plugins[docker] "requests<2.29.2"
+
+      - name: Increase nf_conntrack_max
+        run: sudo sysctl -w net.netfilter.nf_conntrack_max=393216
+
+      - name: Run Molecule tests
+        run: molecule test --scenario-name ha_cluster_kubevip
         working-directory: ./lablabs.rke2
         env:
           PY_COLORS: '1'

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ rke2_channel: stable
 rke2_disable:
 
 # Option to disable kube-proxy
-disable_kube_proxy: true
+disable_kube_proxy: false
 
 # Path to custom manifests deployed during the RKE2 installation
 # It is possible to use Jinja2 templating in the manifests

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,7 +110,7 @@ rke2_channel: stable
 rke2_disable:
 
 # Option to disable kube-proxy
-disable_kube_proxy: true
+disable_kube_proxy: false
 
 # Path to custom manifests deployed during the RKE2 installation
 # It is possible to use Jinja2 templating in the manifests

--- a/molecule/cluster/converge.yml
+++ b/molecule/cluster/converge.yml
@@ -3,7 +3,7 @@
   hosts: all
   become: yes
   vars:
-    rke2_version: v1.27.1+rke2r1
+    rke2_version: v1.22.9+rke2r1
     rke2_snapshooter: native
     rke2_server_node_taints:
       - 'CriticalAddonsOnly=true:NoExecute'

--- a/molecule/cluster/converge.yml
+++ b/molecule/cluster/converge.yml
@@ -3,7 +3,7 @@
   hosts: all
   become: yes
   vars:
-    rke2_version: v1.22.9+rke2r1
+    rke2_version: v1.22.12+rke2r1
     rke2_snapshooter: native
     rke2_server_node_taints:
       - 'CriticalAddonsOnly=true:NoExecute'

--- a/molecule/cluster/converge.yml
+++ b/molecule/cluster/converge.yml
@@ -3,7 +3,7 @@
   hosts: all
   become: yes
   vars:
-    rke2_version: v1.20.15+rke2r1
+    rke2_version: v1.27.1+rke2r1
     rke2_snapshooter: native
     rke2_server_node_taints:
       - 'CriticalAddonsOnly=true:NoExecute'

--- a/molecule/cluster/molecule.yml
+++ b/molecule/cluster/molecule.yml
@@ -4,16 +4,13 @@ dependency:
   command: ansible-playbook ${MOLECULE_PROJECT_DIRECTORY}/molecule/default/dependency.yml -i localhost,
 driver:
   name: docker
-lint: |
-  yamllint -s .
-  ansible-lint --exclude molecule/ --exclude .github/
 platforms:
   - name: node1
-    image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:${MOLECULE_TAG:-latest}"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:latest"
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:${MOLECULE_DOCKER_VOLUMES:-ro}" # Use "ro" for cgroup v1 and "rw" for cgroup v2
-    cgroups_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"private"} # Use "private" for cgroup v1 and "host" for cgroup v2
+    cgroupns_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"private"} # Use "private" for cgroup v1 and "host" for cgroup v2
+    command: ${MOLECULE_DOCKER_COMMAND:-"/usr/sbin/init"}
     privileged: true
     pre_build_image: true
     networks:
@@ -22,11 +19,11 @@ platforms:
       - masters
       - k8s_cluster
   - name: node2
-    image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:${MOLECULE_TAG:-latest}"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:latest"
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:${MOLECULE_DOCKER_VOLUMES:-ro}" # Use "ro" for cgroup v1 and "rw" for cgroup v2
-    cgroups_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"private"} # Use "private" for cgroup v1 and "host" for cgroup v2
+    cgroupns_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"private"} # Use "private" for cgroup v1 and "host" for cgroup v2
+    command: ${MOLECULE_DOCKER_COMMAND:-"/usr/sbin/init"}
     privileged: true
     pre_build_image: true
     networks:
@@ -42,20 +39,20 @@ provisioner:
         rke2_type: server
       workers:
         rke2_type: agent
-
 verifier:
   name: ansible
 scenario:
   name: cluster
   test_sequence:
-    - lint
+    - dependency
+    - cleanup
     - destroy
     - syntax
-    - dependency
     - create
     - prepare
     - converge
     # - idempotence
+    - side_effect
     - verify
     - cleanup
     - destroy

--- a/molecule/cluster/molecule.yml
+++ b/molecule/cluster/molecule.yml
@@ -1,7 +1,7 @@
 ---
 dependency:
   name: 'shell'
-  command: ansible-playbook ${MOLECULE_PROJECT_DIRECTORY}/molecule/default/dependency.yml -i localhost,
+  command: ansible-playbook ${MOLECULE_PROJECT_DIRECTORY}/molecule/cluster/dependency.yml -i localhost,
 driver:
   name: docker
 platforms:

--- a/molecule/cluster/molecule.yml
+++ b/molecule/cluster/molecule.yml
@@ -8,9 +8,9 @@ platforms:
   - name: node1
     image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:latest"
     volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:${MOLECULE_DOCKER_VOLUMES:-ro}" # Use "ro" for cgroup v1 and "rw" for cgroup v2
-    cgroupns_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"private"} # Use "private" for cgroup v1 and "host" for cgroup v2
-    command: ${MOLECULE_DOCKER_COMMAND:-"/usr/sbin/init"}
+      - "/sys/fs/cgroup:/sys/fs/cgroup:${MOLECULE_DOCKER_VOLUMES:-rw}" # Use "ro" for cgroup v1 and "rw" for cgroup v2
+    cgroupns_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"host"} # Use "private" for cgroup v1 and "host" for cgroup v2
+    command: /usr/sbin/init
     privileged: true
     pre_build_image: true
     networks:
@@ -21,9 +21,9 @@ platforms:
   - name: node2
     image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:latest"
     volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:${MOLECULE_DOCKER_VOLUMES:-ro}" # Use "ro" for cgroup v1 and "rw" for cgroup v2
-    cgroupns_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"private"} # Use "private" for cgroup v1 and "host" for cgroup v2
-    command: ${MOLECULE_DOCKER_COMMAND:-"/usr/sbin/init"}
+      - "/sys/fs/cgroup:/sys/fs/cgroup:${MOLECULE_DOCKER_VOLUMES:-rw}" # Use "ro" for cgroup v1 and "rw" for cgroup v2
+    cgroupns_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"host"} # Use "private" for cgroup v1 and "host" for cgroup v2
+    command: /usr/sbin/init
     privileged: true
     pre_build_image: true
     networks:

--- a/molecule/cluster/prepare.yml
+++ b/molecule/cluster/prepare.yml
@@ -10,4 +10,3 @@
       loop:
         - wget
         - curl
-        - apparmor-parser

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,7 +3,7 @@
   hosts: all
   become: yes
   vars:
-    rke2_version: v1.20.15+rke2r1
+    rke2_version: v1.27.1+rke2r1
     rke2_snapshooter: native
   roles:
     - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,16 +4,13 @@ dependency:
   command: ansible-playbook ${MOLECULE_PROJECT_DIRECTORY}/molecule/default/dependency.yml -i localhost,
 driver:
   name: docker
-lint: |
-  yamllint -s .
-  ansible-lint --exclude molecule/ --exclude .github/
 platforms:
   - name: node1
-    image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:${MOLECULE_TAG:-latest}"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:latest"
     volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:${MOLECULE_DOCKER_VOLUMES:-ro}" # Use "ro" for cgroup v1 and "rw" for cgroup v2
-    cgroups_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"private"} # Use "private" for cgroup v1 and "host" for cgroup v2
+      - "/sys/fs/cgroup:/sys/fs/cgroup:${MOLECULE_DOCKER_VOLUMES:-rw}" # Use "ro" for cgroup v1 and "rw" for cgroup v2
+    cgroupns_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"host"} # Use "private" for cgroup v1 and "host" for cgroup v2
+    command: /usr/sbin/init
     privileged: true
     pre_build_image: true
     networks:
@@ -28,14 +25,15 @@ verifier:
 scenario:
   name: default
   test_sequence:
-    - lint
+    - dependency
+    - cleanup
     - destroy
     - syntax
-    - dependency
     - create
     - prepare
     - converge
     # - idempotence
+    - side_effect
     - verify
     - cleanup
     - destroy

--- a/molecule/ha_cluster/converge.yml
+++ b/molecule/ha_cluster/converge.yml
@@ -3,7 +3,7 @@
   hosts: all
   become: yes
   vars:
-    rke2_version: v1.25.3+rke2r1
+    rke2_version: v1.27.1+rke2r1
     rke2_cis_profile: cis-1.23
     rke2_ha_mode: true
     rke2_api_ip: 192.168.123.100

--- a/molecule/ha_cluster/converge.yml
+++ b/molecule/ha_cluster/converge.yml
@@ -4,7 +4,6 @@
   become: yes
   vars:
     rke2_version: v1.27.1+rke2r1
-    rke2_cis_profile: cis-1.23
     rke2_ha_mode: true
     rke2_api_ip: 192.168.123.100
     rke2_snapshooter: native

--- a/molecule/ha_cluster/converge.yml
+++ b/molecule/ha_cluster/converge.yml
@@ -3,7 +3,7 @@
   hosts: all
   become: yes
   vars:
-    rke2_version: v1.27.1+rke2r1
+    rke2_version: v1.22.9+rke2r1
     rke2_ha_mode: true
     rke2_api_ip: 192.168.123.100
     rke2_snapshooter: native

--- a/molecule/ha_cluster/converge.yml
+++ b/molecule/ha_cluster/converge.yml
@@ -3,7 +3,7 @@
   hosts: all
   become: yes
   vars:
-    rke2_version: v1.22.9+rke2r1
+    rke2_version: v1.22.12+rke2r1
     rke2_ha_mode: true
     rke2_api_ip: 192.168.123.100
     rke2_snapshooter: native

--- a/molecule/ha_cluster/molecule.yml
+++ b/molecule/ha_cluster/molecule.yml
@@ -4,16 +4,13 @@ dependency:
   command: ansible-playbook ${MOLECULE_PROJECT_DIRECTORY}/molecule/default/dependency.yml -i localhost,
 driver:
   name: docker
-lint: |
-  yamllint -s .
-  ansible-lint --exclude molecule/ --exclude .github/
 platforms:
   - name: node1
-    image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:${MOLECULE_TAG:-latest}"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:latest"
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:${MOLECULE_DOCKER_VOLUMES:-ro}" # Use "ro" for cgroup v1 and "rw" for cgroup v2
-    cgroups_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"private"} # Use "private" for cgroup v1 and "host" for cgroup v2
+    cgroupns_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"private"} # Use "private" for cgroup v1 and "host" for cgroup v2
+    command: ${MOLECULE_DOCKER_COMMAND:-"/usr/sbin/init"}
     privileged: true
     pre_build_image: true
     networks:
@@ -22,11 +19,11 @@ platforms:
       - masters
       - k8s_cluster
   - name: node2
-    image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:${MOLECULE_TAG:-latest}"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:latest"
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:${MOLECULE_DOCKER_VOLUMES:-ro}" # Use "ro" for cgroup v1 and "rw" for cgroup v2
-    cgroups_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"private"} # Use "private" for cgroup v1 and "host" for cgroup v2
+    cgroupns_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"private"} # Use "private" for cgroup v1 and "host" for cgroup v2
+    command: ${MOLECULE_DOCKER_COMMAND:-"/usr/sbin/init"}
     privileged: true
     pre_build_image: true
     networks:
@@ -35,11 +32,11 @@ platforms:
       - masters
       - k8s_cluster
   - name: node3
-    image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:${MOLECULE_TAG:-latest}"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:latest"
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:${MOLECULE_DOCKER_VOLUMES:-ro}" # Use "ro" for cgroup v1 and "rw" for cgroup v2
-    cgroups_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"private"} # Use "private" for cgroup v1 and "host" for cgroup v2
+    cgroupns_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"private"} # Use "private" for cgroup v1 and "host" for cgroup v2
+    command: ${MOLECULE_DOCKER_COMMAND:-"/usr/sbin/init"}
     privileged: true
     pre_build_image: true
     networks:
@@ -48,11 +45,11 @@ platforms:
       - masters
       - k8s_cluster
   - name: node4
-    image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:${MOLECULE_TAG:-latest}"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    image: "geerlingguy/docker-${MOLECULE_IMAGE:-ubuntu2204}-ansible:latest"
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:${MOLECULE_DOCKER_VOLUMES:-ro}" # Use "ro" for cgroup v1 and "rw" for cgroup v2
-    cgroups_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"private"} # Use "private" for cgroup v1 and "host" for cgroup v2
+    cgroupns_mode: ${MOLECULE_DOCKER_CGROUPS_MODE:-"private"} # Use "private" for cgroup v1 and "host" for cgroup v2
+    command: ${MOLECULE_DOCKER_COMMAND:-"/usr/sbin/init"}
     privileged: true
     pre_build_image: true
     networks:
@@ -78,14 +75,15 @@ verifier:
 scenario:
   name: ha_cluster
   test_sequence:
-    - lint
+    - dependency
+    - cleanup
     - destroy
     - syntax
-    - dependency
     - create
     - prepare
     - converge
     # - idempotence
+    - side_effect
     - verify
     - cleanup
     - destroy

--- a/molecule/ha_cluster_kubevip/converge.yml
+++ b/molecule/ha_cluster_kubevip/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  become: yes
+  vars:
+    rke2_server_taint: true
+    rke2_cni: calico
+    rke2_api_ip: 192.168.123.100
+    rke2_version: v1.27.1+rke2r1
+    rke2_cis_profile: cis-1.23
+    rke2_snapshooter: native
+    rke2_ha_mode_keepalived: false
+    rke2_ha_mode: true
+    rke2_ha_mode_kubevip: true
+    rke2_kubevip_cloud_provider_enable: true
+    rke2_kubevip_svc_enable: true
+    rke2_loadbalancer_ip_range: 192.168.123.1-192.168.123.50
+  roles:
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/ha_cluster_kubevip/converge.yml
+++ b/molecule/ha_cluster_kubevip/converge.yml
@@ -6,7 +6,7 @@
     rke2_server_taint: true
     rke2_cni: calico
     rke2_api_ip: 192.168.123.100
-    rke2_version: v1.27.1+rke2r1
+    rke2_version: v1.22.9+rke2r1
     rke2_cis_profile: cis-1.23
     rke2_snapshooter: native
     rke2_ha_mode_keepalived: false

--- a/molecule/ha_cluster_kubevip/converge.yml
+++ b/molecule/ha_cluster_kubevip/converge.yml
@@ -6,7 +6,7 @@
     rke2_server_taint: true
     rke2_cni: calico
     rke2_api_ip: 192.168.123.100
-    rke2_version: v1.22.9+rke2r1
+    rke2_version: v1.22.12+rke2r1
     rke2_cis_profile: cis-1.23
     rke2_snapshooter: native
     rke2_ha_mode_keepalived: false

--- a/molecule/ha_cluster_kubevip/dependency.yml
+++ b/molecule/ha_cluster_kubevip/dependency.yml
@@ -1,0 +1,17 @@
+---
+- name: Dependency
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    ansible_python_interpreter: python3
+  tasks:
+    - name: "Create docker network"
+      docker_network:
+        name: "rke2net"
+        ipam_config:
+          - subnet: "192.168.123.0/24"
+            gateway: "192.168.123.254"
+        state: present
+        labels:
+          owner: molecule

--- a/molecule/ha_cluster_kubevip/molecule.yml
+++ b/molecule/ha_cluster_kubevip/molecule.yml
@@ -1,7 +1,7 @@
 ---
 dependency:
   name: 'shell'
-  command: ansible-playbook ${MOLECULE_PROJECT_DIRECTORY}/molecule/ha_cluster/dependency.yml -i localhost,
+  command: ansible-playbook ${MOLECULE_PROJECT_DIRECTORY}/molecule/ha_cluster_kubevip/dependency.yml -i localhost,
 driver:
   name: docker
 platforms:
@@ -69,11 +69,10 @@ provisioner:
         rke2_type: agent
         k8s_node_label:
           - worker=true
-
 verifier:
   name: ansible
 scenario:
-  name: ha_cluster
+  name: ha_cluster_kubevip
   test_sequence:
     - dependency
     - cleanup

--- a/molecule/ha_cluster_kubevip/prepare.yml
+++ b/molecule/ha_cluster_kubevip/prepare.yml
@@ -10,4 +10,3 @@
       loop:
         - wget
         - curl
-        - apparmor-parser

--- a/molecule/ha_cluster_kubevip/verify.yml
+++ b/molecule/ha_cluster_kubevip/verify.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Verify
+  hosts: node1
+  gather_facts: false
+  vars:
+    rke2_data_path: /var/lib/rancher/rke2
+  tasks:
+    - name: Verify RKE2
+      shell: |
+        set -e
+        set -o pipefail
+        {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep " Ready" | wc -l
+      args:
+        executable: /bin/bash
+      register: nodes
+
+    - name: Check Nodes
+      assert:
+        that:
+          - groups.all | length == nodes.stdout | int
+        quiet: true


### PR DESCRIPTION
# Description

This PR:
Adds Molecule 5.0 compatibility (fixes #145 )
Changes the default value for `disable_kube_proxy` variable to be aligned with default RKE2 configuartion (fixes #146 )
Updates the CI jobs for `molecule test` to run on Ubuntu 22.04 host with cgroup v2
Adds  to the CI jobs a workaround for urllib3 issue https://github.com/docker/docker-py/issues/3113

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
molecule test
