### PR TITLE
Change service restart logic

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,6 @@
   loop_control:
     loop_var: _host_item
   when:
-  - not rke2_drain_node_during_upgrade
   - hostvars[_host_item].inventory_hostname == inventory_hostname
   - config_file_is_changed is defined and config_file_is_changed.changed
 


### PR DESCRIPTION
Disable checking for (lack of) `rke2_drain_node_during_upgrade` when deciding whether to restart services.

# Description

Currently when deciding whether to restart services after config change it is checked whether `rke2_drain_node_during_upgrade` is not set to `true`. I don't believe this check makes any sense in this place, and it prevents service restarts when configuration changed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
