### PR TITLE
Register changes to other config files as also requiring service restart

### DIFF
--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -30,6 +30,7 @@
     group: root
     mode: 0644
   when: rke2_custom_registry_mirrors.0.endpoint | length > 0
+  register: config_file_is_changed
 
 - name: Register if we need to do a etcd restore from file
   ansible.builtin.set_fact:

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -35,6 +35,7 @@
     group: root
     mode: 0644
   when: rke2_custom_registry_mirrors.0.endpoint | length > 0
+  register: config_file_is_changed
 
 - name: Start RKE2 service on the rest of the nodes
   ansible.builtin.systemd:

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -25,6 +25,7 @@
     group: root
     mode: 0644
   when: rke2_custom_registry_mirrors.0.endpoint | length > 0
+  register: config_file_is_changed
 
 - name: Start RKE2 service on the server node
   ansible.builtin.systemd:


### PR DESCRIPTION
# Description

Restart service also when `registries.yaml` changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
