### PR TITLE
Fixed Keepalived when ip addr contains VIP

### DIFF
--- a/templates/check_apiserver.sh.j2
+++ b/templates/check_apiserver.sh.j2
@@ -4,6 +4,6 @@ errorExit() {
     exit 1
 }
 curl --silent --max-time 2 --insecure https://localhost:{{rke2_apiserver_dest_port}}/healthz --cert {{rke2_data_path}}/server/tls/client-ca.crt --key {{rke2_data_path}}/server/tls/client-ca.key -o /dev/null || errorExit "Error GET https://localhost:{{rke2_apiserver_dest_port}}/healthz"
-if ip addr | grep -q {{rke2_api_ip}}; then
+if ip addr | grep -wq {{rke2_api_ip}}; then
     curl --silent --max-time 2 --insecure https://{{rke2_api_ip}}:{{rke2_apiserver_dest_port}}/healthz --cert {{rke2_data_path}}/server/tls/client-ca.crt --key {{rke2_data_path}}/server/tls/client-ca.key -o /dev/null || errorExit "Error GET https://{{rke2_api_ip}}:{{rke2_apiserver_dest_port}}/healthz"
 fi

--- a/templates/check_rke2server.sh.j2
+++ b/templates/check_rke2server.sh.j2
@@ -4,6 +4,6 @@ errorExit() {
     exit 1
 }
 curl --silent --max-time 2 --insecure https://localhost:9345/ -o /dev/null || errorExit "Error GET https://localhost:9345/"
-if ip addr | grep -q {{rke2_api_ip}}; then
+if ip addr | grep -wq {{rke2_api_ip}}; then
     curl --silent --max-time 2 --insecure https://{{rke2_api_ip}}:9345/ -o /dev/null || errorExit "Error GET https://{{rke2_api_ip}}:9345/"
 fi


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
When my VIP is almost like to broadcast then "grep -q" will always be true in all cases.
For example:
1. VIP: 10.1.1.25
2. Broadcast: 10.1.1.255
then:
when running "ip addr | grep 10.1.1.25" on a non-VIP node also returns "inet 10.1.1.18/24 brd **10.1.1.25**5 scope global ens192"
should add:
-w : Matches only word/words instead of substring.
