### PR TITLE
change registry deployment so it works more intuitive and out of the box

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -120,13 +120,13 @@ rke2_custom_manifests:
 rke2_static_pods:
 
 # Configure custom Containerd Registry
-rke2_custom_registry_mirrors:
-  - name:
-    endpoint: {}
+rke2_custom_registry_mirrors: []
+  # - name:
+  #   endpoint: {}
 #   rewrite: '"^rancher/(.*)": "mirrorproject/rancher-images/$1"'
 
 # Configure custom Containerd Registry additional configuration
-# rke2_custom_registry_configs:
+rke2_custom_registry_configs: []
 #   - endpoint:
 #     config:
 

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -29,7 +29,7 @@
     owner: root
     group: root
     mode: 0644
-  when: rke2_custom_registry_mirrors.0.endpoint | length > 0
+  when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   register: config_file_is_changed
 
 - name: Register if we need to do a etcd restore from file

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -34,7 +34,7 @@
     owner: root
     group: root
     mode: 0644
-  when: rke2_custom_registry_mirrors.0.endpoint | length > 0
+  when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   register: config_file_is_changed
 
 - name: Start RKE2 service on the rest of the nodes

--- a/templates/registries.yaml.j2
+++ b/templates/registries.yaml.j2
@@ -1,3 +1,4 @@
+{% if rke2_custom_registry_mirrors | length > 0 %}
 mirrors:
 {% for mirror in rke2_custom_registry_mirrors %}
   {{ mirror.name }}:
@@ -10,7 +11,8 @@ mirrors:
       {{ mirror.rewrite }}
 {% endif %}
 {% endfor %}
-{% if rke2_custom_registry_configs is defined %}
+{% endif %}
+{% if rke2_custom_registry_mirrors | length > 0 %}
 configs:
 {% for config in rke2_custom_registry_configs %}
   {{ config.endpoint }}:


### PR DESCRIPTION
# Description

When i was configuring a custom registry i noticed that the config for the mirror was enabled by default. But in my case i don't need the mirroring option. I changed the role so those two can be deployed separately. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
## How Has This Been Tested?

For the test i overwrited the two variables in `group_vars`: 
```yaml

rke2_custom_registry_mirrors: []

rke2_custom_registry_configs:
  - endpoint: gitlab.domain.internal:5678
    config:
      auth:
        username: kubernetes
        password: kubernetes-password
```
I have tested this and it works. It creates this registries.yaml:

```yaml
configs:
  gitlab.domain.internal:5678
    auth:
        username: kubernetes
        password: kubernetes-password
```
