### PR TITLE
docs: align readme file with default vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,13 @@ rke2_custom_manifests:
 rke2_static_pods:
 
 # Configure custom Containerd Registry
-rke2_custom_registry_mirrors:
-  - name:
-    endpoint: {}
+rke2_custom_registry_mirrors: []
+  # - name:
+  #   endpoint: {}
 #   rewrite: '"^rancher/(.*)": "mirrorproject/rancher-images/$1"'
 
 # Configure custom Containerd Registry additional configuration
-# rke2_custom_registry_configs:
+rke2_custom_registry_configs: []
 #   - endpoint:
 #     config:
 


### PR DESCRIPTION
# Description

Aligned README file with default vars

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
-
