### PR TITLE
#142 Typo fix in parameter name for custom registry

### DIFF
--- a/templates/registries.yaml.j2
+++ b/templates/registries.yaml.j2
@@ -12,7 +12,7 @@ mirrors:
 {% endif %}
 {% endfor %}
 {% endif %}
-{% if rke2_custom_registry_mirrors | length > 0 %}
+{% if rke2_custom_registry_configs | length > 0 %}
 configs:
 {% for config in rke2_custom_registry_configs %}
   {{ config.endpoint }}:


### PR DESCRIPTION
# Description

In order to create config for custom registries check is performed on existence of `rke2_custom_registry_mirrors` instead of `rke2_custom_registry_configs`. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Ran locally for own RKE2 cluster.
