### PR TITLE
fix /usr/local/bin/rke2: No such file or directory

### DIFF
--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -74,20 +74,6 @@
     path: /usr/local
   register: usr_local
 
-- name: Set RKE2 bin path
-  ansible.builtin.set_fact:
-    rke2_bin_path: "{{ '/usr/local/bin/rke2' if usr_local.stat.writeable == True else ' /opt/rke2/bin/rke2' }}"
-
-- name: Check RKE2 version
-  ansible.builtin.shell: |
-    set -o pipefail
-    {{ rke2_bin_path }} --version | grep -E "rke2 version" | awk '{print $3}'
-  args:
-    executable: /bin/bash
-  changed_when: false
-  register: installed_rke2_version
-  when: '"rke2-server.service" in ansible_facts.services'
-
 - name: Run AirGap RKE2 script
   ansible.builtin.command:
     cmd: "{{ rke2_install_script_dir }}/rke2.sh"
@@ -109,6 +95,20 @@
   changed_when: false
   when: (rke2_version != ( installed_rke2_version.stdout | default({})) and (not rke2_airgap_mode))
         or ((installed_rke2_version is not defined) and (not rke2_airgap_mode))
+
+- name: Set RKE2 bin path
+  ansible.builtin.set_fact:
+    rke2_bin_path: "{{ '/usr/local/bin/rke2' if usr_local.stat.writeable == True else ' /opt/rke2/bin/rke2' }}"
+
+- name: Check RKE2 version
+  ansible.builtin.shell: |
+    set -o pipefail
+    {{ rke2_bin_path }} --version | grep -E "rke2 version" | awk '{print $3}'
+  args:
+    executable: /bin/bash
+  changed_when: false
+  register: installed_rke2_version
+  when: '"rke2-server.service" in ansible_facts.services'
 
 - name: Copy Custom Manifests
   ansible.builtin.template:


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

rke2_bin_path is only created after running RKE2 script, so the current order caused error "/usr/local/bin/rke2: No such file or directory"

The commit change the order of tasks to fix the above issue.
 
https://github.com/rancher/rke2/blob/master/install.sh#L370
