### PR TITLE
decrease permissions config.yaml and registries.yaml

### DIFF
--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -19,7 +19,7 @@
     dest: /etc/rancher/rke2/config.yaml
     owner: root
     group: root
-    mode: 0644
+    mode: 0600
   register: config_file_is_changed
 
 - name: Copy Containerd Registry Configuration file
@@ -28,7 +28,7 @@
     dest: /etc/rancher/rke2/registries.yaml
     owner: root
     group: root
-    mode: 0644
+    mode: 0600
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   register: config_file_is_changed
 

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -24,7 +24,7 @@
     dest: /etc/rancher/rke2/config.yaml
     owner: root
     group: root
-    mode: 0644
+    mode: 0600
   register: config_file_is_changed
 
 - name: Copy Containerd Registry Configuration file
@@ -33,7 +33,7 @@
     dest: /etc/rancher/rke2/registries.yaml
     owner: root
     group: root
-    mode: 0644
+    mode: 0600
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   register: config_file_is_changed
 

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -14,7 +14,7 @@
     dest: /etc/rancher/rke2/config.yaml
     owner: root
     group: root
-    mode: 0644
+    mode: 0600
   register: config_file_is_changed
 
 - name: Copy Containerd Registry Configuration file
@@ -23,7 +23,7 @@
     dest: /etc/rancher/rke2/registries.yaml
     owner: root
     group: root
-    mode: 0644
+    mode: 0600
   when: rke2_custom_registry_mirrors.0.endpoint | length > 0
   register: config_file_is_changed
 


### PR DESCRIPTION
# Description

Two files (possibly) containing secrets are currently configured to be world readable:
- `config.yaml` contains the secret token for adding nodes to the cluster
- `registries.yaml` can possibly contain the password for basic auth registries. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
