### PR TITLE
Kube VIP improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ rke2_kubevip_cloud_provider_enable: true
 # Enable kube-vip to watch Services of type LoadBalancer
 rke2_kubevip_svc_enable: true
 
+# Specify which image is used for kube-vip container
+rke2_kubevip_image: ghcr.io/kube-vip/kube-vip:v0.5.5
+
 # Add additional SANs in k8s API TLS cert
 rke2_additional_sans: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,9 @@ rke2_kubevip_cloud_provider_enable: true
 # Enable kube-vip to watch Services of type LoadBalancer
 rke2_kubevip_svc_enable: true
 
+# Specify which image is used for kube-vip container
+rke2_kubevip_image: ghcr.io/kube-vip/kube-vip:v0.5.5
+
 # Add additional SANs in k8s API TLS cert
 rke2_additional_sans: []
 

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -65,7 +65,6 @@ spec:
         - name: prometheus_server
           value: :2112
         image: ghcr.io/kube-vip/kube-vip:v0.5.5
-        imagePullPolicy: Always
         name: kube-vip
         resources: {}
         securityContext:

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -4,7 +4,6 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: kube-vip-ds
-    app.kubernetes.io/version: v0.5.5
   name: kube-vip-ds
   namespace: kube-system
 spec:
@@ -16,7 +15,6 @@ spec:
       creationTimestamp: null
       labels:
         app.kubernetes.io/name: kube-vip-ds
-        app.kubernetes.io/version: v0.5.5
     spec:
       affinity:
         nodeAffinity:
@@ -64,7 +62,7 @@ spec:
           value: "{{ rke2_api_ip }}"
         - name: prometheus_server
           value: :2112
-        image: ghcr.io/kube-vip/kube-vip:v0.5.5
+        image: "{{ rke2_kubevip_image }}"
         name: kube-vip
         resources: {}
         securityContext:
@@ -80,8 +78,3 @@ spec:
       - effect: NoExecute
         operator: Exists
   updateStrategy: {}
-status:
-  currentNumberScheduled: 0
-  desiredNumberScheduled: 0
-  numberMisscheduled: 0
-  numberReady: 0


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->

This PR has two main changes:

- uses default imagePullPolicy for kube-vip images to allow bootstrap in air-gapped environments without external registry  (images shipped as tarballs with `rke2_airgap_copy_additional_tarballs`).
- allows specifying kube-vip image as an ansible variable to allow using different image and allow easy upgrades.

Additionally this brings some cleanup to kube-vip manifests by removing version label (it may be incorrect when someone specifies different image) and removing `.status` subresource as it is server-side generated.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->

We are running this in production already using a forked ansible role.
