### PR TITLE
feat: Add support for rke2_cni: none

### DIFF
--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -111,7 +111,7 @@
   - '"kubelet has sufficient memory available"  in node_status.stdout_lines'
   - '"kubelet has no disk pressure"  in node_status.stdout_lines'
   - '"kubelet has sufficient PID available"  in node_status.stdout_lines'
-  - '"cni plugin not initialized" in node_status.stdout'
+  - ('"cni plugin not initialized" in node_status.stdout' or '"kubelet is posting ready status." in node_status.stdout')
   retries: 100
   delay: 15
   when: rke2_cni == 'none'

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -100,7 +100,23 @@
     enabled: false
     masked: true
 
-- name: Wait for the first server be ready
+- name: Wait for the first server be ready - no CNI
+  ansible.builtin.shell: |
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get node "{{ inventory_hostname }}" -o jsonpath='{range .status.conditions[*]}{.message}{"\n"}{end}'
+  args:
+    executable: /bin/bash
+  changed_when: false
+  register: node_status
+  until:
+  - '"kubelet has sufficient memory available"  in node_status.stdout_lines'
+  - '"kubelet has no disk pressure"  in node_status.stdout_lines'
+  - '"kubelet has sufficient PID available"  in node_status.stdout_lines'
+  - '"cni plugin not initialized" in node_status.stdout'
+  retries: 100
+  delay: 15
+  when: rke2_cni == 'none'
+
+- name: Wait for the first server be ready - with CNI
   ansible.builtin.shell: |
     set -o pipefail
     {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep "{{ inventory_hostname }}"
@@ -112,6 +128,7 @@
     '" Ready "  in first_server.stdout'
   retries: 40
   delay: 15
+  when: rke2_cni != 'none'
 
 - name: Restore etcd - remove old <node>.node-password.rke2 secrets
   ansible.builtin.shell: |

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -57,7 +57,26 @@
   with_items:
     - "{{ (['agent', 'server'] | reject('match', rke2_type) | list) }}"
 
-- name: Wait for remaining nodes to be ready
+- name: Wait for remaining nodes to be ready - no CNI
+  ansible.builtin.shell: |
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get node "{{ item }}" -o jsonpath='{range .status.conditions[*]}{.message}{"\n"}{end}'
+  args:
+    executable: /bin/bash
+  changed_when: false
+  register: node_status
+  until:
+    - '"kubelet has sufficient memory available"  in node_status.stdout_lines'
+    - '"kubelet has no disk pressure"  in node_status.stdout_lines'
+    - '"kubelet has sufficient PID available"  in node_status.stdout_lines'
+    - ('"cni plugin not initialized" in node_status.stdout' or '"kubelet is posting ready status." in node_status.stdout')
+  retries: 100
+  delay: 15
+  loop: "{{ groups[rke2_cluster_group_name] }}"
+  delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
+  run_once: true
+  when: rke2_cni == 'none'
+
+- name: Wait for remaining nodes to be ready - with CNI
   ansible.builtin.shell: |
     set -o pipefail
     {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep " Ready" | wc -l
@@ -71,3 +90,4 @@
   delay: 15
   delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
   run_once: true
+  when: rke2_cni != 'none'

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -46,7 +46,7 @@
   - '"kubelet has sufficient memory available"  in node_status.stdout_lines'
   - '"kubelet has no disk pressure"  in node_status.stdout_lines'
   - '"kubelet has sufficient PID available"  in node_status.stdout_lines'
-  - '"cni plugin not initialized" in node_status.stdout'
+  - ('"cni plugin not initialized" in node_status.stdout' or '"kubelet is posting ready status." in node_status.stdout')
   retries: 100
   delay: 15
   when: rke2_cni == 'none'

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -35,7 +35,23 @@
   environment:
     RKE2_TOKEN: "{{ rke2_token }}"
 
-- name: Wait for the RKE2 server to be ready
+- name: Wait for the first server be ready - no CNI
+  ansible.builtin.shell: |
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get node "{{ inventory_hostname }}" -o jsonpath='{range .status.conditions[*]}{.message}{"\n"}{end}'
+  args:
+    executable: /bin/bash
+  changed_when: false
+  register: node_status
+  until:
+  - '"kubelet has sufficient memory available"  in node_status.stdout_lines'
+  - '"kubelet has no disk pressure"  in node_status.stdout_lines'
+  - '"kubelet has sufficient PID available"  in node_status.stdout_lines'
+  - '"cni plugin not initialized" in node_status.stdout'
+  retries: 100
+  delay: 15
+  when: rke2_cni == 'none'
+
+- name: Wait for the first server be ready - with CNI
   ansible.builtin.shell: |
     set -o pipefail
     {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes | grep "{{ inventory_hostname }}"
@@ -47,3 +63,4 @@
     - '" Ready "  in first_server.stdout'
   retries: 40
   delay: 15
+  when: rke2_cni != 'none'


### PR DESCRIPTION
# Description

Added a different readiness check when the rke2_cni option is set to none.
Current behavior if rke2_cni: none is set is that the playbook hangs indefinitely when trying to check if nodes are ready. (Since nodes can't report ready state without an initialized CNI)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Tested the following rke2_cni:none scenarios using Vagrant and Ansible:
- Single node cluster: Works
- Single master with multiple workers: Works
- Multi-master cluster with High Availability mode:
    1. If disable_kube_proxy: false - keepalived, kubevip and preconfigured LB (used HAProxy) all work
    2. if disable_kube_proxy: true - keepalived and preconfigured LB (used HAProxy) work, kubevip **does not**, but i think this cannot be made to work since kubevip is dependant on kube-proxy.

