### PR TITLE
Add the ability to customize the kube-controller-manager and kube-scheduler arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,16 @@ rke2_agents_group_name: workers
 #   - "option=value"
 #   - "HTTP_PROXY=http://your-proxy.example.com:8888"
 
+# (Optional) Customize default kube-controller-manager arguments
+# This functionality allows appending the argument if it is not present by default or replacing it if it already exists.
+# rke2_kube_controller_manager_arg:
+#   - "bind-address=0.0.0.0"
+
+# (Optional) Customize default kube-scheduler arguments
+# This functionality allows appending the argument if it is not present by default or replacing it if it already exists.
+# rke2_kube_scheduler_arg:
+#   - "bind-address=0.0.0.0"
+
 # Cordon, drain the node which is being upgraded. Uncordon the node once the RKE2 upgraded
 rke2_drain_node_during_upgrade: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -218,6 +218,16 @@ rke2_agents_group_name: workers
 #   - "option=value"
 #   - "HTTP_PROXY=http://your-proxy.example.com:8888"
 
+# (Optional) Customize default kube-controller-manager arguments
+# This functionality allows appending the argument if it is not present by default or replacing it if it already exists.
+# rke2_kube_controller_manager_arg:
+#   - "bind-address=0.0.0.0"
+
+# (Optional) Customize default kube-scheduler arguments
+# This functionality allows appending the argument if it is not present by default or replacing it if it already exists.
+# rke2_kube_scheduler_arg:
+#   - "bind-address=0.0.0.0"
+
 # Cordon, drain the node which is being upgraded. Uncordon the node once the RKE2 upgraded
 rke2_drain_node_during_upgrade: false
 

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -56,3 +56,15 @@ profile: {{ rke2_cis_profile }}
 {{ option }}
 {% endfor %}
 {% endif %}
+{% if ( rke2_kube_controller_manager_arg is defined ) %}
+kube-controller-manager-arg:
+{% for argument in rke2_kube_controller_manager_arg %}
+  - {{ argument }}
+{% endfor %}
+{% endif %}
+{% if ( rke2_kube_scheduler_arg is defined ) %}
+kube-scheduler-arg:
+{% for argument in rke2_kube_scheduler_arg %}
+  - {{ argument }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
# Description

I recently installed the kube-prometheus-stack on my RKE2 cluster and I had to modify the bind address for both kube-controller-manager and kube-scheduler. This enable the ability to do so.

## Type of change

- arguments customization of kube-controller-manager
- arguments customization of kube-manager

## How Has This Been Tested?

Tested on my cluster :

```
[…]
TASK [rke2 : Copy rke2 config] ********************************************************************************************************************************************************************************************************
--- before: /etc/rancher/rke2/config.yaml                                                                                                                                                                                              
+++ after: /home/drustan/.ansible/tmp/ansible-local-1078711o6wjcsgb/tmprae1u2ef/config.yaml.j2                                                                                                                                          
@@ -10,3 +10,8 @@                                                                                                                                                                                                                      
 snapshotter: overlayfs                                                                                                                                                                                                                
 node-name: k8s.xxxxx.xxx                                                                                                                                                                                                  
 disable-kube-proxy: true                                                                                                                                                                                                              
 etcd-expose-metrics: true                                                                                                                                                                                                             
+kube-controller-manager-arg:                                                                                                                                                                                                          
+  - bind-address=0.0.0.0                                                                                                                                                                                                              
+kube-scheduler-arg:                                                                                                                                                                                                                   
+  - bind-address=0.0.0.0                                                                                                                                                                                                              
                                                                                                                                                                                                                                       
changed: [k8s.xxxxx.xxx] 
[…]
```
