### PR TITLE
Copy kube-vip manifests before connecting to first node

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,12 +21,6 @@
   when:
     - rke2_ha_mode | bool
 
-- name: Prepare very first server node in the cluster
-  ansible.builtin.include_tasks: first_server.yml
-  when:
-    - inventory_hostname == groups[rke2_servers_group_name].0
-    - active_server is not defined
-
 - name: Copy kube-vip manifests to the masternode
   ansible.builtin.include_tasks: kubevip.yml
   when:
@@ -34,6 +28,12 @@
     - rke2_ha_mode | bool
     - rke2_ha_mode_kubevip | bool
     - not rke2_ha_mode_keepalived | bool
+
+- name: Prepare very first server node in the cluster
+  ansible.builtin.include_tasks: first_server.yml
+  when:
+    - inventory_hostname == groups[rke2_servers_group_name].0
+    - active_server is not defined
 
 - name: Prepare and join remaining nodes of the cluster
   ansible.builtin.include_tasks: remaining_nodes.yml


### PR DESCRIPTION
# Description

Allowing to connect to cluster over VIP during bootstrap using kube-vip. Fixing https://github.com/lablabs/ansible-role-rke2/issues/172

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Starting a new cluster with kube-vip

