### PR TITLE
fix: Add creation of manifests directory before copying kube-vip manifests

### DIFF
--- a/tasks/kubevip.yml
+++ b/tasks/kubevip.yml
@@ -1,4 +1,12 @@
 ---
+- name: Create the RKE2 manifests directory
+  ansible.builtin.file:
+    state: directory
+    path: "{{ rke2_data_path }}/server/manifests"
+    owner: root
+    group: root
+    mode: 0700
+
 - name: Copy kube-vip files to first server
   ansible.builtin.template:
     src: "{{ item }}"


### PR DESCRIPTION
# Description
Added task to create "{{ rke2_data_path }}/server/manifests" directory before placing kube-vip manifests into it.
Fixes: #175 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Tested in the following scenarios:

- HA mode enabled + kube-vip enabled + both with and without CNI:
  - Single master with multiple workers - works
  - Multi-master cluster with multiple workers - works
