### PR TITLE
Fix RKE2 services restart when configuration changes

### DIFF
--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -20,7 +20,7 @@
     owner: root
     group: root
     mode: 0600
-  register: config_file_is_changed
+  register: rke2_config_file_is_changed
 
 - name: Copy Containerd Registry Configuration file
   ansible.builtin.template:
@@ -30,7 +30,7 @@
     group: root
     mode: 0600
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
-  register: config_file_is_changed
+  register: containerd_config_file_is_changed
 
 - name: Register if we need to do a etcd restore from file
   ansible.builtin.set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,7 +55,7 @@
     loop_var: _host_item
   when:
   - hostvars[_host_item].inventory_hostname == inventory_hostname
-  - config_file_is_changed is defined and config_file_is_changed.changed
+  - (rke2_config_file_is_changed is defined and rke2_config_file_is_changed.changed) or (containerd_config_file_is_changed and containerd_config_file_is_changed.changed)
 
 - name: Final steps
   ansible.builtin.include_tasks: summary.yml

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -25,7 +25,7 @@
     owner: root
     group: root
     mode: 0600
-  register: config_file_is_changed
+  register: rke2_config_file_is_changed
 
 - name: Copy Containerd Registry Configuration file
   ansible.builtin.template:
@@ -35,7 +35,7 @@
     group: root
     mode: 0600
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
-  register: config_file_is_changed
+  register: containerd_config_file_is_changed
 
 - name: Start RKE2 service on the rest of the nodes
   ansible.builtin.systemd:

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -15,7 +15,7 @@
     owner: root
     group: root
     mode: 0600
-  register: config_file_is_changed
+  register: rke2_config_file_is_changed
 
 - name: Copy Containerd Registry Configuration file
   ansible.builtin.template:
@@ -25,7 +25,7 @@
     group: root
     mode: 0600
   when: rke2_custom_registry_mirrors.0.endpoint | length > 0
-  register: config_file_is_changed
+  register: containerd_config_file_is_changed
 
 - name: Start RKE2 service on the server node
   ansible.builtin.systemd:


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->

This fixes an issue where the same variable is being used to detect a change in the configuration of the RKE2 config file and the containerd configuration. This means that if the RKE2 config file changes but not the containerd configuration, the result of config_file_is_changed.changed is going to be false although there was a change. This addresses the issue by using 2 different variables for detecting the 2 changes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
