### PR TITLE
Improve rolling restart version detection

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,3 +12,11 @@
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
+
+- name: Config file changed
+  ansible.builtin.set_fact:
+    rke2_restart_needed: true
+
+- name: Service (re)started
+  ansible.builtin.set_fact:
+    rke2_restart_needed: false

--- a/tasks/change_config.yml
+++ b/tasks/change_config.yml
@@ -2,6 +2,7 @@
   ansible.builtin.service:
     name: "{{ rke2_service_name }}"
     state: restarted
+  notify: "Service (re)started"
 
 - name: Wait for all nodes to be ready again
   ansible.builtin.shell: |

--- a/tasks/change_config.yml
+++ b/tasks/change_config.yml
@@ -1,7 +1,6 @@
----
 - name: Restart RKE2 service on {{ inventory_hostname }}
   ansible.builtin.service:
-    name: "rke2-{{ rke2_type }}.service"
+    name: "{{ rke2_service_name }}"
     state: restarted
 
 - name: Wait for all nodes to be ready again

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -20,7 +20,7 @@
     owner: root
     group: root
     mode: 0600
-  register: rke2_config_file_is_changed
+  notify: "Config file changed"
 
 - name: Copy Containerd Registry Configuration file
   ansible.builtin.template:
@@ -30,7 +30,7 @@
     group: root
     mode: 0600
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
-  register: containerd_config_file_is_changed
+  notify: "Config file changed"
 
 - name: Register if we need to do a etcd restore from file
   ansible.builtin.set_fact:
@@ -86,6 +86,7 @@
         --token {{ rke2_token }}
       register: task_output # <- Registers the command output.
       changed_when: task_output.rc != 0 # <- Uses the return code to define when the task has changed.
+
 - name: Start RKE2 service on the first server
   ansible.builtin.systemd:
     name: "rke2-server.service"
@@ -93,6 +94,7 @@
     enabled: true
   environment:
     RKE2_TOKEN: "{{ rke2_token }}"
+  notify: "Service (re)started"
 
 - name: Mask RKE2 agent service on the first server
   ansible.builtin.systemd:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,7 @@
     loop_var: _host_item
   when:
     - hostvars[_host_item].inventory_hostname == inventory_hostname
+    - installed_version != "not installed"
     - rke2_version != running_version
 
 - name: Rolling restart when config files change
@@ -57,6 +58,7 @@
     loop_var: _host_item
   when:
     - hostvars[_host_item].inventory_hostname == inventory_hostname
+    - installed_version != "not installed"
     # Should not restart if the version changed triggering a drain restart
     - rke2_version == running_version
     - >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,21 +41,27 @@
     - active_server is defined
     - groups[rke2_cluster_group_name] | length | int >= 2
 
-- name: Rolling restart
+- name: Rolling cordon and drain restart when version changes
   ansible.builtin.include_tasks: rolling_restart.yml
   with_items: "{{ groups[rke2_cluster_group_name] }}"
   loop_control:
     loop_var: _host_item
-  when: ( hostvars[_host_item].inventory_hostname == inventory_hostname ) and installed_rke2_version.stdout is defined and rke2_version != ( installed_rke2_version.stdout | default({}) )
+  when:
+    - hostvars[_host_item].inventory_hostname == inventory_hostname
+    - rke2_version != running_version
 
-- name: Restart service when config file is changed
+- name: Rolling restart when config files change
   ansible.builtin.include_tasks: change_config.yml
   with_items: "{{ groups[rke2_cluster_group_name] }}"
   loop_control:
     loop_var: _host_item
   when:
-  - hostvars[_host_item].inventory_hostname == inventory_hostname
-  - (rke2_config_file_is_changed is defined and rke2_config_file_is_changed.changed) or (containerd_config_file_is_changed is defined and containerd_config_file_is_changed.changed)
+    - hostvars[_host_item].inventory_hostname == inventory_hostname
+    # Should not restart if the version changed triggering a drain restart
+    - rke2_version == running_version
+    - >
+      (rke2_config_file_is_changed is defined and rke2_config_file_is_changed.changed) or
+      (containerd_config_file_is_changed is defined and containerd_config_file_is_changed.changed)
 
 - name: Final steps
   ansible.builtin.include_tasks: summary.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,6 +51,9 @@
     - installed_version != "not installed"
     - rke2_version != running_version
 
+- name: Flush handlers
+  ansible.builtin.meta: flush_handlers
+
 - name: Rolling restart when config files change
   ansible.builtin.include_tasks: change_config.yml
   with_items: "{{ groups[rke2_cluster_group_name] }}"
@@ -58,12 +61,7 @@
     loop_var: _host_item
   when:
     - hostvars[_host_item].inventory_hostname == inventory_hostname
-    - installed_version != "not installed"
-    # Should not restart if the version changed triggering a drain restart
-    - rke2_version == running_version
-    - >
-      (rke2_config_file_is_changed is defined and rke2_config_file_is_changed.changed) or
-      (containerd_config_file_is_changed is defined and containerd_config_file_is_changed.changed)
+    - rke2_restart_needed
 
 - name: Final steps
   ansible.builtin.include_tasks: summary.yml

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -39,7 +39,7 @@
 
 - name: Start RKE2 service on the rest of the nodes
   ansible.builtin.systemd:
-    name: "rke2-{{ rke2_type }}.service"
+    name: "{{ rke2_service_name }}"
     state: started
     enabled: true
   retries: 10

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -25,7 +25,7 @@
     owner: root
     group: root
     mode: 0600
-  register: rke2_config_file_is_changed
+  notify: "Config file changed"
 
 - name: Copy Containerd Registry Configuration file
   ansible.builtin.template:
@@ -35,7 +35,7 @@
     group: root
     mode: 0600
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
-  register: containerd_config_file_is_changed
+  notify: "Config file changed"
 
 - name: Start RKE2 service on the rest of the nodes
   ansible.builtin.systemd:
@@ -48,6 +48,7 @@
   until: result is not failed
   environment:
     RKE2_TOKEN: "{{ rke2_token }}"
+  notify: "Service (re)started"
 
 - name: Mask other RKE2 service on the rest of the nodes
   ansible.builtin.systemd:

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -74,6 +74,50 @@
     path: /usr/local
   register: usr_local
 
+- name: Set RKE2 bin path
+  ansible.builtin.set_fact:
+    rke2_bin_path: "{{ '/usr/local/bin/rke2' if usr_local.stat.writeable == True else ' /opt/rke2/bin/rke2' }}"
+
+- name: Check RKE2 version
+  ansible.builtin.shell: |
+    set -euo pipefail
+
+    rke2_bin_path="{{ rke2_bin_path }}"
+    rke2_service_name="{{ rke2_service_name }}"
+    rke2_version="{{ rke2_version }}"
+
+    if [ -f "$rke2_bin_path" ]; then
+      installed_version="$($rke2_bin_path --version | grep -E "rke2 version" | awk '{print $3}')"
+    else
+      installed_version="not installed"
+    fi
+
+    if systemctl is-active --quiet $rke2_service_name && rke2_service_pid=$(systemctl show $rke2_service_name --property MainPID --value); then
+      rke2_bin_path="$(realpath "/proc/$rke2_service_pid/exe")"
+    fi
+
+    # Linux appends the target of removed proc exe with ' (deleted)', making the path unavailable.
+    if [ -f "$rke2_bin_path" ]; then
+      running_version="$($rke2_bin_path --version | grep -E "rke2 version" | awk '{print $3}')"
+    elif [ "$installed_version" = "not installed" ]; then
+      running_version="$rke2_version"
+    else
+      running_version="outdated"
+    fi
+
+    echo "{\"installed_version\":\"$installed_version\",\"running_version\":\"$running_version\"}"
+  args:
+    executable: /bin/bash
+  changed_when: false
+  register: versions_check
+
+- name: Set RKE2 versions
+  ansible.builtin.set_fact:
+    installed_version: "{{ versions.installed_version }}"
+    running_version: "{{ versions.running_version }}"
+  vars:
+    versions: "{{ versions_check.stdout | from_json }}"
+
 - name: Run AirGap RKE2 script
   ansible.builtin.command:
     cmd: "{{ rke2_install_script_dir }}/rke2.sh"
@@ -81,8 +125,7 @@
     INSTALL_RKE2_ARTIFACT_PATH: "{{ rke2_artifact_path }}"
     INSTALL_RKE2_AGENT_IMAGES_DIR: "{{ rke2_data_path }}/agent/images"
   changed_when: false
-  when: (rke2_version != ( installed_rke2_version.stdout | default({})) and (rke2_airgap_mode))
-        or ((installed_rke2_version is not defined) and rke2_airgap_mode)
+  when: rke2_version != installed_version and rke2_airgap_mode
 
 - name: Run RKE2 script
   ansible.builtin.command:
@@ -93,22 +136,7 @@
     INSTALL_RKE2_CHANNEL: "{{ rke2_channel }}"
     INSTALL_RKE2_METHOD: "{{ rke2_method }}"
   changed_when: false
-  when: (rke2_version != ( installed_rke2_version.stdout | default({})) and (not rke2_airgap_mode))
-        or ((installed_rke2_version is not defined) and (not rke2_airgap_mode))
-
-- name: Set RKE2 bin path
-  ansible.builtin.set_fact:
-    rke2_bin_path: "{{ '/usr/local/bin/rke2' if usr_local.stat.writeable == True else ' /opt/rke2/bin/rke2' }}"
-
-- name: Check RKE2 version
-  ansible.builtin.shell: |
-    set -o pipefail
-    {{ rke2_bin_path }} --version | grep -E "rke2 version" | awk '{print $3}'
-  args:
-    executable: /bin/bash
-  changed_when: false
-  register: installed_rke2_version
-  when: '"rke2-server.service" in ansible_facts.services'
+  when: rke2_version != installed_version and not rke2_airgap_mode
 
 - name: Copy Custom Manifests
   ansible.builtin.template:

--- a/tasks/rolling_restart.yml
+++ b/tasks/rolling_restart.yml
@@ -23,6 +23,7 @@
   ansible.builtin.service:
     name: "{{ rke2_service_name }}"
     state: restarted
+  notify: "Service (re)started"
 
 - name: Wait for all nodes to be ready again
   ansible.builtin.shell: |

--- a/tasks/rolling_restart.yml
+++ b/tasks/rolling_restart.yml
@@ -21,7 +21,7 @@
 
 - name: Restart RKE2 service on {{ inventory_hostname }}
   ansible.builtin.service:
-    name: "rke2-{{ rke2_type }}.service"
+    name: "{{ rke2_service_name }}"
     state: restarted
 
 - name: Wait for all nodes to be ready again

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -15,7 +15,7 @@
     owner: root
     group: root
     mode: 0600
-  register: rke2_config_file_is_changed
+  notify: "Config file changed"
 
 - name: Copy Containerd Registry Configuration file
   ansible.builtin.template:
@@ -25,7 +25,7 @@
     group: root
     mode: 0600
   when: rke2_custom_registry_mirrors.0.endpoint | length > 0
-  register: containerd_config_file_is_changed
+  notify: "Config file changed"
 
 - name: Start RKE2 service on the server node
   ansible.builtin.systemd:
@@ -34,6 +34,7 @@
     enabled: true
   environment:
     RKE2_TOKEN: "{{ rke2_token }}"
+  notify: "Service (re)started"
 
 - name: Wait for the first server be ready - no CNI
   ansible.builtin.shell: |

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -29,7 +29,7 @@
 
 - name: Start RKE2 service on the server node
   ansible.builtin.systemd:
-    name: "rke2-{{ rke2_type }}.service"
+    name: "{{ rke2_service_name }}"
     state: started
     enabled: true
   environment:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,3 +2,4 @@
 
 # RKE2 installation method (do not change this option)
 rke2_method: tar
+rke2_service_name: "rke2-{{ rke2_type }}.service"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,3 +3,4 @@
 # RKE2 installation method (do not change this option)
 rke2_method: tar
 rke2_service_name: "rke2-{{ rke2_type }}.service"
+rke2_restart_needed: false


### PR DESCRIPTION
# Description

Attempting to trigger the rolling_restart on an existing cluster didn't seem to work.

While investigating, it seemed the installed_version was used for more logic than it can describe. 

In order to detect the need for a restart, the running binary version needs to be inspected separately from the installed version.

This also fixes a bug where rke2 is restarted on a fresh launch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

I tried to upgrade a cluster with the role as-is and noticed no rolling restart.

After applying these changes (with a manual change to prevent one node from upgrading), all other nodes upgraded.

After removing the temporary change, the last node also updated correctly.
