### PR TITLE
feat: Configure default prometheus port in kube vip

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ rke2_kubevip_ipvs_lb_enable: false
 # - param: lb_port
 #   value: 6443
 
+#Prometheus metrics port for kube-vip
+rke2_kubevip_metrics_port: 2112
+
 # Add additional SANs in k8s API TLS cert
 rke2_additional_sans: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,6 +60,9 @@ rke2_kubevip_ipvs_lb_enable: false
 # - param: lb_port
 #   value: 6443
 
+#Prometheus metrics port for kube-vip
+rke2_kubevip_metrics_port: 2112
+
 # Add additional SANs in k8s API TLS cert
 rke2_additional_sans: []
 

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -61,7 +61,7 @@ spec:
         - name: address
           value: "{{ rke2_api_ip }}"
         - name: prometheus_server
-          value: :2112
+          value: ":{{ rke2_kubevip_metrics_port }}"
         - name: lb_enable
           value: "{{ rke2_kubevip_ipvs_lb_enable }}"
 {% if rke2_kubevip_args  is defined %}
@@ -74,7 +74,7 @@ spec:
         name: kube-vip
         ports:
         - name: metrics
-          containerPort: 2112
+          containerPort: "{{ rke2_kubevip_metrics_port }}"
         resources: {}
         securityContext:
           capabilities:

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -72,6 +72,9 @@ spec:
 {% endif %}
         image: "{{ rke2_kubevip_image }}"
         name: kube-vip
+        ports:
+        - name: metrics
+          containerPort: 2112
         resources: {}
         securityContext:
           capabilities:


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->
Explicitly configure the default port for Prometheus to deploy Podmonitor and monitor metrics.

Example:
```yaml
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  name: kube-vip
  namespace: kube-system
  labels:
    app.kubernetes.io/name: kube-vip-podmonitor
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: kube-vip-ds
  podMetricsEndpoints:
    - port: metrics
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
We have implemented the modified Kubevip DaemonSet and Podmonitor, and verified the Prometheus targets.