### PR TITLE
feat: Added option to customize kubelet arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,10 @@ rke2_wait_for_all_pods_to_be_ready: false
 
 # Enable debug mode (rke2-service)
 rke2_debug: false
+
+# (Optional) Customize default kubelet arguments
+# rke_kubelet_arg:
+#   - "--system-reserved=cpu=100m,memory=100Mi"
 ```
 
 ## Inventory file example

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ rke2_wait_for_all_pods_to_be_ready: false
 rke2_debug: false
 
 # (Optional) Customize default kubelet arguments
-# rke_kubelet_arg:
+# rke2_kubelet_arg:
 #   - "--system-reserved=cpu=100m,memory=100Mi"
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -251,3 +251,7 @@ rke2_wait_for_all_pods_to_be_ready: false
 
 # Enable debug mode (rke2-service)
 rke2_debug: false
+
+# (Optional) Customize default kubelet arguments
+# rke_kubelet_arg:
+#   - "--system-reserved=cpu=100m,memory=100Mi"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -259,5 +259,5 @@ rke2_wait_for_all_pods_to_be_ready: false
 rke2_debug: false
 
 # (Optional) Customize default kubelet arguments
-# rke_kubelet_arg:
+# rke2_kubelet_arg:
 #   - "--system-reserved=cpu=100m,memory=100Mi"

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -71,9 +71,9 @@ kube-scheduler-arg:
 {% if (rke2_debug | bool ) %}
 debug: true
 {% endif %}
-{% if ( rke_kubelet_arg is defined ) %}
+{% if ( rke2_kubelet_arg is defined ) %}
 kubelet-arg:
-{% for argument in rke_kubelet_arg %}
+{% for argument in rke2_kubelet_arg %}
   - {{ argument }}
 {% endfor %}
 {% endif %}

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -71,3 +71,9 @@ kube-scheduler-arg:
 {% if (rke2_debug | bool ) %}
 debug: true
 {% endif %}
+{% if ( rke_kubelet_arg is defined ) %}
+kubelet-arg:
+{% for argument in rke_kubelet_arg %}
+  - {{ argument }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
# Description

Added option to customize kubelet arguments [(https://docs.rke2.io/reference/server_config#agentflags)](https://docs.rke2.io/reference/server_config#agentflags). 

I used the variable _rke2_server_options_ somewhat successfully too, but it becomes very messy very fast since it requires specifying all kubelet arguments on a single line like so:

```
rke2_server_options:
  - "kubelet-arg: ['--system-reserved=cpu=100m,memory=100Mi,pid=100000','--kube-reserved=cpu=80m,memory=1400Mi,pid=100000','--eviction-hard=memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<15%','--enforce-node-allocatable=pods', '--pod-max-pids=32768']"
```

I would constantly break it trying to add new/adjust existing arguments so i created a new variable so that arguments can be passed like below:

```
rke_kubelet_arg:
  - "--system-reserved=cpu=100m,memory=100Mi,pid=100000"
  - "--kube-reserved=cpu=80m,memory=1400Mi,pid=100000"
  - "--eviction-hard=memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<15%"
  - "--enforce-node-allocatable=pods"
  - "--pod-max-pids=32768"
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation, etc.)

## How Has This Been Tested?
I have been successfully using this variable on all my environments both dev/test and production in the last month or so.

