### PR TITLE
Set permissions for downloaded kubeconf

### DIFF
--- a/tasks/summary.yml
+++ b/tasks/summary.yml
@@ -13,6 +13,7 @@
 - name: Replace loopback IP by master server IP
   ansible.builtin.replace:
     path: "{{ rke2_download_kubeconf_path }}/{{ rke2_download_kubeconf_file_name }}"
+    mode: '0600'
     regexp: '127.0.0.1'
     replace: "{{ rke2_api_ip | default(hostvars[groups[rke2_servers_group_name].0].ansible_host) }}"
   delegate_to: localhost


### PR DESCRIPTION
# Description

The kubeconfig allows full access to the cluster, so it should be kept secure. Previously it was readable by everyone, now only by the user running Ansible.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
I executed the role and checked the file permissions.
