### PR TITLE
bug: wrong variable type for containerPort

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ rke2_kubevip_ipvs_lb_enable: false
 # - param: lb_port
 #   value: 6443
 
-#Prometheus metrics port for kube-vip
+# Prometheus metrics port for kube-vip
 rke2_kubevip_metrics_port: 2112
 
 # Add additional SANs in k8s API TLS cert

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,7 +60,7 @@ rke2_kubevip_ipvs_lb_enable: false
 # - param: lb_port
 #   value: 6443
 
-#Prometheus metrics port for kube-vip
+# Prometheus metrics port for kube-vip
 rke2_kubevip_metrics_port: 2112
 
 # Add additional SANs in k8s API TLS cert

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -74,7 +74,7 @@ spec:
         name: kube-vip
         ports:
         - name: metrics
-          containerPort: "{{ rke2_kubevip_metrics_port }}"
+          containerPort: {{ rke2_kubevip_metrics_port | int }}
         resources: {}
         securityContext:
           capabilities:


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->

The containerPort has been declared as a string. This is causing an error:
```yaml
level=error msg="Failed to process config: failed to process /var/lib/rancher/rke2/server/manifests/kube-vip.yml: failed to update kube-system/kube-vip-ds apps/v1, Kind=DaemonSet for  kube-system/kube-vip: json: cannot unmarshal string into Go struct field ContainerPort.spec.template.spec.containers.ports.containerPort of type int32"
```

The containerPort should be set as int.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
Deployed in the test environment.