### PR TITLE
adding option to disable builtin cloud controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ disable_kube_proxy: false
 # Option to disable builtin cloud controller - mostly for onprem 
 rke2_disable_cloud_controller: false
 
+# Cloud provider to use for the cluster (aws, azure, gce, openstack, vsphere, external) 
+# applicable only if rke2_disable_cloud_controller is true
+rke2_cloud_provider_name: "rke2"
+
 # Path to custom manifests deployed during the RKE2 installation
 # It is possible to use Jinja2 templating in the manifests
 rke2_custom_manifests:

--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ rke2_disable:
 # Option to disable kube-proxy
 disable_kube_proxy: false
 
-# Option to disable builtin cloud controller - mostly for onprem 
+# Option to disable builtin cloud controller - mostly for onprem
 rke2_disable_cloud_controller: false
 
-# Cloud provider to use for the cluster (aws, azure, gce, openstack, vsphere, external) 
+# Cloud provider to use for the cluster (aws, azure, gce, openstack, vsphere, external)
 # applicable only if rke2_disable_cloud_controller is true
 rke2_cloud_provider_name: "rke2"
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ rke2_disable:
 # Option to disable kube-proxy
 disable_kube_proxy: false
 
+# Option to disable builtin cloud controller - mostly for onprem 
+rke2_disable_cloud_controller: false
+
 # Path to custom manifests deployed during the RKE2 installation
 # It is possible to use Jinja2 templating in the manifests
 rke2_custom_manifests:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -145,6 +145,9 @@ rke2_disable:
 # Option to disable kube-proxy
 disable_kube_proxy: false
 
+# Option to disable builtin cloud controller - mostly for onprem 
+rke2_disable_cloud_controller: false
+
 # Path to custom manifests deployed during the RKE2 installation
 # It is possible to use Jinja2 templating in the manifests
 rke2_custom_manifests:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -148,6 +148,10 @@ disable_kube_proxy: false
 # Option to disable builtin cloud controller - mostly for onprem 
 rke2_disable_cloud_controller: false
 
+# Cloud provider to use for the cluster (aws, azure, gce, openstack, vsphere, external) 
+# applicable only if rke2_disable_cloud_controller is true
+rke2_cloud_provider_name: "external"
+
 # Path to custom manifests deployed during the RKE2 installation
 # It is possible to use Jinja2 templating in the manifests
 rke2_custom_manifests:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -145,10 +145,10 @@ rke2_disable:
 # Option to disable kube-proxy
 disable_kube_proxy: false
 
-# Option to disable builtin cloud controller - mostly for onprem 
+# Option to disable builtin cloud controller - mostly for onprem
 rke2_disable_cloud_controller: false
 
-# Cloud provider to use for the cluster (aws, azure, gce, openstack, vsphere, external) 
+# Cloud provider to use for the cluster (aws, azure, gce, openstack, vsphere, external)
 # applicable only if rke2_disable_cloud_controller is true
 rke2_cloud_provider_name: "external"
 

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -81,4 +81,3 @@ kubelet-arg:
 disable-cloud-controller: true
 cloud-provider-name: "{{ rke2_cloud_provider_name }}"
 {% endif %}
-

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -77,3 +77,7 @@ kubelet-arg:
   - {{ argument }}
 {% endfor %}
 {% endif %}
+{% if (rke2_disable_cloud_controller | bool ) %}
+disable-cloud-controller	: true
+{% endif %}
+

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -78,6 +78,7 @@ kubelet-arg:
 {% endfor %}
 {% endif %}
 {% if (rke2_disable_cloud_controller | bool ) %}
-disable-cloud-controller	: true
+disable-cloud-controller: true
+cloud-provider-name: "{{ rke2_cloud_provider_name }}"
 {% endif %}
 


### PR DESCRIPTION
# Description

option to disable built-in cloud controller to deploy different cloud controller mostly for on prem and talos CCM 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
on my own clusters
