### PR TITLE
Fix `active_server` for multi-cluster deployments

### DIFF
--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -145,7 +145,9 @@
 - name: Set an Active Server variable
   ansible.builtin.set_fact:
     active_server: "{{ inventory_hostname }}"
-  run_once: true
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  loop: "{{ groups[rke2_cluster_group_name] }}"
 
 - name: Get all nodes
   ansible.builtin.shell: |

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -73,9 +73,9 @@
   retries: 100
   delay: 15
   loop: "{{ groups[rke2_cluster_group_name] }}"
-  delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
-  run_once: true
-  when: rke2_cni == 'none'
+  when:
+    - rke2_cni == 'none'
+    - inventory_hostname == active_server or inventory_hostname == groups[rke2_servers_group_name].0
 
 - name: Wait for remaining nodes to be ready - with CNI
   ansible.builtin.shell: |
@@ -89,6 +89,6 @@
     "groups[rke2_cluster_group_name] | length == all_ready_nodes.stdout | int"
   retries: 100
   delay: 15
-  delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
-  run_once: true
-  when: rke2_cni != 'none'
+  when:
+    - rke2_cni != 'none'
+    - inventory_hostname == active_server or inventory_hostname == groups[rke2_servers_group_name].0

--- a/tasks/summary.yml
+++ b/tasks/summary.yml
@@ -5,10 +5,9 @@
     src: /etc/rancher/rke2/rke2.yaml
     dest: "{{ rke2_download_kubeconf_path }}/{{ rke2_download_kubeconf_file_name }}"
     flat: yes
-  delegate_to: "{{ groups[rke2_servers_group_name].0 }}"
-  run_once: true
   when:
   - rke2_download_kubeconf | bool
+  - inventory_hostname == groups[rke2_servers_group_name].0
 
 - name: Replace loopback IP by master server IP
   ansible.builtin.replace:

--- a/tasks/summary.yml
+++ b/tasks/summary.yml
@@ -31,11 +31,9 @@
       args:
         executable: /bin/bash
       changed_when: false
-      run_once: true
       retries: 5
       register: nodes_summary
 
     - name: K8s nodes state
       ansible.builtin.debug:
         var: nodes_summary.stdout_lines
-      run_once: true


### PR DESCRIPTION
# Description

When addressing multiple clusters at once within a play, the `active_server` would only be determined once - when processing the very first cluster.
`active_server` would then be used to delegate the task to, to wait for all nodes and pods to be ready again.

When all clusters are sized equally, this wouldn't cause any real troubles (yet still be incorrect in terms of actually verifying the state of the cluster's nodes), since the number of nodes in the first cluster would match the number of nodes in any other cluster checked for the nodes to be up.

But as soon as a cluster with a different number of nodes is present, this would cause failures/timeouts, since the check waiting for all nodes to be up and running again would never reach the expected number.

By not utilizing `run_once` and verifying for the include of `first_server.yml`, whether `active_server` is a member of the current cluster, this problem can be prevented.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
- added multiple clusters with different numbers of nodes to my inventory
- utilized the `rke2` successfully with those changes
- saw the `rke2` role fail without those changes
