### PR TITLE
Fix CIS hardening rke2-cis-sysctl.conf path

### DIFF
--- a/tasks/cis.yml
+++ b/tasks/cis.yml
@@ -15,7 +15,7 @@
 
 - name: Copy systemctl config file for kernel hardening
   ansible.builtin.copy:
-    src: /usr/local/share/rke2/rke2-cis-sysctl.conf
+    src: "{{ '/usr/local/share/rke2/rke2-cis-sysctl.conf' if usr_local.stat.writeable == True else '/opt/rke2/share/rke2/rke2-cis-sysctl.conf' }}" 
     dest: /etc/sysctl.d/60-rke2-cis.conf
     mode: 0600
     remote_src: true

--- a/tasks/cis.yml
+++ b/tasks/cis.yml
@@ -15,7 +15,7 @@
 
 - name: Copy systemctl config file for kernel hardening
   ansible.builtin.copy:
-    src: "{{ '/usr/local/share/rke2/rke2-cis-sysctl.conf' if usr_local.stat.writeable == True else '/opt/rke2/share/rke2/rke2-cis-sysctl.conf' }}" 
+    src: "{{ '/usr/local/share/rke2/rke2-cis-sysctl.conf' if usr_local.stat.writeable == True else '/opt/rke2/share/rke2/rke2-cis-sysctl.conf' }}"
     dest: /etc/sysctl.d/60-rke2-cis.conf
     mode: 0600
     remote_src: true


### PR DESCRIPTION
# Description

The CIS hardening currently expects the file to be at `/usr/local/share/rke2/rke2-cis-sysctl.conf` but if `/usr/local` is not writeable it will be at `/opt/rke2/share/rke2/rke2-cis-sysctl.conf`. This PR simply adds a check if the directory is writeable and adjusts the path accordingly. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Tested locally using molecule and RKE2 v1.27.12+rke2r1
