### PR TITLE
Fix daemonset

### DIFF
--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -83,6 +83,9 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+        volumeMounts:
+        - mountPath: /etc/kubernetes/admin.conf
+          name: kubeconfig
       hostAliases:
       - hostnames:
         - kubernetes
@@ -94,4 +97,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         operator: Exists
+      volumes:
+      - hostPath:
+          path: /etc/rancher/rke2/rke2.yaml
+          type: File
+        name: kubeconfig
   updateStrategy: {}

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -83,6 +83,10 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+      hostAliases:
+      - hostnames:
+        - kubernetes
+        ip: 127.0.0.1
       hostNetwork: true
       serviceAccountName: kube-vip
       tolerations:


### PR DESCRIPTION
# Description

Use same hostAlias strategy as static pods use to get around race condition when using a CNI like Cilium where kube-vip needs the API service IP to exist to get a lease, and Cilium needs the VIP to exist to allow the lease traffic to succeed.

References:
- https://kube-vip.io/docs/installation/static/#example-arp-manifest
- https://github.com/kube-vip/kube-vip/issues/721#issuecomment-1890470512

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)