### PR TITLE
fix: configuration of kube-vip per-service leader election

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ rke2_kubevip_ipvs_lb_enable: false
 # Enable layer 4 load balancing for control plane using IPVS kernel module
 # Must use kube-vip version 0.4.0 or later
 
-rke2_kubevip_service_election_enable: false
+rke2_kubevip_service_election_enable: true
 # By default ARP mode provides a HA implementation of a VIP (your service IP address) which will receive traffic on the kube-vip leader.
 # To circumvent this kube-vip has implemented a new function which is "leader election per service",
 # instead of one node becoming the leader for all services an election is held across all kube-vip instances and the leader from that election becomes the holder of that service. Ultimately,

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,7 +51,7 @@ rke2_kubevip_ipvs_lb_enable: false
 # Enable layer 4 load balancing for control plane using IPVS kernel module
 # Must use kube-vip version 0.4.0 or later
 
-rke2_kubevip_service_election_enable: false
+rke2_kubevip_service_election_enable: true
 # By default ARP mode provides a HA implementation of a VIP (your service IP address) which will receive traffic on the kube-vip leader.
 # To circumvent this kube-vip has implemented a new function which is "leader election per service",
 # instead of one node becoming the leader for all services an election is held across all kube-vip instances and the leader from that election becomes the holder of that service. Ultimately,

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -49,8 +49,6 @@ spec:
         - name: svc_enable
           value: "{{ rke2_kubevip_svc_enable }}"
         - name: svc_election
-          value: "true"
-        - name: enableServicesElection
           value: "{{ rke2_kubevip_service_election_enable }}"
         - name: vip_leaderelection
           value: "true"


### PR DESCRIPTION
# Description

Previously used `enableServicesElection` is not an accepted environment variable but a field in the kube-vip YAML config file.

* The related environment variable is `svc_election`, which is already present in the DaemonSet template
* Use `rke2_kubevip_service_election_enable` to set the `svc_election` in DaemonSet template
* Change default value to `true` to maintain original behavior

<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
