### PR TITLE
Add partition check for /usr/local

### DIFF
--- a/tasks/cis.yml
+++ b/tasks/cis.yml
@@ -13,9 +13,13 @@
     comment: etcd user
     state: present
 
+- name: Check if separate partition
+  command: grep '/usr/local ' /proc/mounts
+  register: partition_result
+
 - name: Copy systemctl config file for kernel hardening
   ansible.builtin.copy:
-    src: "{{ '/usr/local/share/rke2/rke2-cis-sysctl.conf' if usr_local.stat.writeable == True else '/opt/rke2/share/rke2/rke2-cis-sysctl.conf' }}"
+    src: "{{ '/usr/local/share/rke2/rke2-cis-sysctl.conf' if (usr_local.stat.writeable) and (partition_result.rc == 1) else '/opt/rke2/share/rke2/rke2-cis-sysctl.conf' }}"
     dest: /etc/sysctl.d/60-rke2-cis.conf
     mode: 0600
     remote_src: true

--- a/tasks/cis.yml
+++ b/tasks/cis.yml
@@ -14,7 +14,8 @@
     state: present
 
 - name: Check if separate partition
-  command: grep '/usr/local ' /proc/mounts
+  ansible.builtin.command: grep '/usr/local ' /proc/mounts
+  changed_when: false
   register: partition_result
 
 - name: Copy systemctl config file for kernel hardening

--- a/tasks/cis.yml
+++ b/tasks/cis.yml
@@ -15,7 +15,7 @@
 
 - name: Copy systemctl config file for kernel hardening
   ansible.builtin.copy:
-    src: "{{ '/usr/local/share/rke2/rke2-cis-sysctl.conf' if usr_local.stat.writeable == True else '/opt/rke2/share/rke2/rke2-cis-sysctl.conf' }}" 
+    src: "{{ '/usr/local/share/rke2/rke2-cis-sysctl.conf' if usr_local.stat.writeable == True else '/opt/rke2/share/rke2/rke2-cis-sysctl.conf' }}"
     dest: /etc/sysctl.d/60-rke2-cis.conf
     mode: 0600
     remote_src: true


### PR DESCRIPTION
# Description

The initial PR only solved the issue if /usr/local is not writeable. The RKE2 install scripts also checks if /usr/local is a separate partition which was not checked by the role before. This PR adds the partition check.
Issue: https://github.com/lablabs/ansible-role-rke2/issues/193

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
This has been tested in own airgapped environment on RHEL9, ansible-role-rke2 version 1.33.0 and RKE2 v1.26.11+rke2r1
