### PR TITLE
Allow configuration of nginx ingress controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,10 @@ rke2_agents_group_name: workers
 # rke2_kube_scheduler_arg:
 #   - "bind-address=0.0.0.0"
 
+# Configure the nginx default certificate: https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-ssl-certificate
+# Leave empty to not set `--default-ssl-certificate`
+rke2_ingress_nginx_default_certificate: ""
+
 # Cordon, drain the node which is being upgraded. Uncordon the node once the RKE2 upgraded
 rke2_drain_node_during_upgrade: false
 

--- a/README.md
+++ b/README.md
@@ -304,9 +304,12 @@ rke2_agents_group_name: workers
 # rke2_kube_scheduler_arg:
 #   - "bind-address=0.0.0.0"
 
-# Configure the nginx default certificate: https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-ssl-certificate
-# Leave empty to not set `--default-ssl-certificate`
-rke2_ingress_nginx_default_certificate: ""
+# (Optional) Configure nginx via HelmChartConfig: https://docs.rke2.io/networking/networking_services#nginx-ingress-controller
+# rke2_ingress_nginx_values:
+#   controller:
+#     config:
+#       use-forwarded-headers: "true"
+rke2_ingress_nginx_values: {}
 
 # Cordon, drain the node which is being upgraded. Uncordon the node once the RKE2 upgraded
 rke2_drain_node_during_upgrade: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -265,6 +265,10 @@ rke2_agents_group_name: workers
 # rke2_kube_scheduler_arg:
 #   - "bind-address=0.0.0.0"
 
+# Configure the nginx default certificate: https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-ssl-certificate
+# Leave empty to not set `--default-ssl-certificate`
+rke2_ingress_nginx_default_certificate: ""
+
 # Cordon, drain the node which is being upgraded. Uncordon the node once the RKE2 upgraded
 rke2_drain_node_during_upgrade: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -265,9 +265,12 @@ rke2_agents_group_name: workers
 # rke2_kube_scheduler_arg:
 #   - "bind-address=0.0.0.0"
 
-# Configure the nginx default certificate: https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-ssl-certificate
-# Leave empty to not set `--default-ssl-certificate`
-rke2_ingress_nginx_default_certificate: ""
+# (Optional) Configure nginx via HelmChartConfig: https://docs.rke2.io/networking/networking_services#nginx-ingress-controller
+# rke2_ingress_nginx_values:
+#   controller:
+#     config:
+#       use-forwarded-headers: "true"
+rke2_ingress_nginx_values: {}
 
 # Cordon, drain the node which is being upgraded. Uncordon the node once the RKE2 upgraded
 rke2_drain_node_during_upgrade: false

--- a/tasks/ingress-nginx.yml
+++ b/tasks/ingress-nginx.yml
@@ -1,3 +1,12 @@
+---
+- name: Create the RKE2 manifests directory
+  ansible.builtin.file:
+    state: directory
+    path: "{{ rke2_data_path }}/server/manifests"
+    owner: root
+    group: root
+    mode: 0700
+
 - name: Copy ingress-nginx files to first server
   ansible.builtin.template:
     src: "templates/ingress-nginx-config.yml.j2"

--- a/tasks/ingress-nginx.yml
+++ b/tasks/ingress-nginx.yml
@@ -1,0 +1,7 @@
+- name: Copy ingress-nginx files to first server
+  ansible.builtin.template:
+    src: "templates/ingress-nginx-config.yml.j2"
+    dest: "{{ rke2_data_path }}/server/manifests/rke2-ingress-nginx-config.yaml"
+    owner: root
+    group: root
+    mode: 0664

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,11 @@
     - rke2_ha_mode_kubevip | bool
     - not rke2_ha_mode_keepalived | bool
 
+- name: Copy ingress-nginx manifests to the masternode
+  ansible.builtin.include_tasks: ingress-nginx.yml
+  when:
+    - inventory_hostname == groups[rke2_servers_group_name].0
+
 - name: Prepare very first server node in the cluster
   ansible.builtin.include_tasks: first_server.yml
   when:

--- a/templates/ingress-nginx-config.yml.j2
+++ b/templates/ingress-nginx-config.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-ingress-nginx
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    controller:
+      extraArgs:
+{% if rke2_ingress_nginx_default_certificate | length > 0 %}
+        default-ssl-certificate: "{{ rke2_ingress_nginx_default_certificate }}"
+{% endif %}

--- a/templates/ingress-nginx-config.yml.j2
+++ b/templates/ingress-nginx-config.yml.j2
@@ -5,8 +5,6 @@ metadata:
   namespace: kube-system
 spec:
   valuesContent: |-
-    controller:
-      extraArgs:
-{% if rke2_ingress_nginx_default_certificate | length > 0 %}
-        default-ssl-certificate: "{{ rke2_ingress_nginx_default_certificate }}"
+{% if rke2_ingress_nginx_values | length > 0 %}
+    {{ rke2_ingress_nginx_values | to_nice_yaml | indent(2) }}
 {% endif %}


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->

Allow configuration of default nginx certificate.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->

I executed the role on my cluster and set `rke2_ingress_nginx_default_certificate: "cert-manager/default-cert"`. With cert-manager I created a certificate in the secret `cert-manager/default-cert`.