### PR TITLE
Fix removing old nodes after restore if rke2-server already started

### DIFF
--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -148,22 +148,3 @@
   delegate_to: "{{ item }}"
   delegate_facts: true
   loop: "{{ groups[rke2_cluster_group_name] }}"
-
-- name: Get all nodes
-  ansible.builtin.shell: |
-    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
-    get nodes --no-headers | awk '{print $1}'
-  args:
-    executable: /bin/bash
-  changed_when: false
-  register: node_names
-
-- name: Restore etcd - remove old nodes
-  ansible.builtin.shell: |
-    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
-    delete node {{ item }} 2>&1 || true
-  args:
-    executable: /bin/bash
-  with_items: "{{ node_names.stdout_lines | difference(groups[rke2_cluster_group_name]) }}"
-  changed_when: false
-  when: inventory_hostname != item and (do_etcd_restore is defined or do_etcd_restore_from_s3 is defined)

--- a/tasks/first_server_restore.yml
+++ b/tasks/first_server_restore.yml
@@ -1,0 +1,17 @@
+- name: Restore etcd - get all nodes
+  ansible.builtin.shell: |
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+    get nodes --no-headers -o custom-columns=":metadata.name"
+  args:
+    executable: /bin/bash
+  changed_when: false
+  register: node_names
+
+- name: Restore etcd - remove old nodes
+  ansible.builtin.shell: |
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+    delete node {{ item }} 2>&1 || true
+  args:
+    executable: /bin/bash
+  with_items: "{{ node_names.stdout_lines | difference(groups[rke2_cluster_group_name]) }}"
+  changed_when: false

--- a/tasks/first_server_restore.yml
+++ b/tasks/first_server_restore.yml
@@ -1,6 +1,5 @@
 - name: Restore etcd - get all nodes
   ansible.builtin.shell: |
-    set -o pipefail
     {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
     get nodes --no-headers -o custom-columns=":metadata.name"
   args:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,12 @@
     - inventory_hostname == groups[rke2_servers_group_name].0
     - active_server is not defined
 
+- name: Restore etcd specific tasks
+  ansible.builtin.include_tasks: first_server_restore.yml
+  when:
+    - inventory_hostname == active_server or inventory_hostname == groups[rke2_servers_group_name].0
+    - do_etcd_restore is defined or do_etcd_restore_from_s3 is defined
+
 - name: Prepare and join remaining nodes of the cluster
   ansible.builtin.include_tasks: remaining_nodes.yml
   when:


### PR DESCRIPTION
# Description

If rke2-server happened to start on the first node before the node removal section, nodes would not be removed.

This was because the removal was in `first_server.yml` which is gated by `active_server is not defined`.

https://github.com/lablabs/ansible-role-rke2/blob/main/tasks/main.yml#L46-L49

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
TBD