### PR TITLE
fix: Include ingress-nginx.yml only if rke2_ingress_nginx_values is not empty

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,8 @@
   ansible.builtin.include_tasks: ingress-nginx.yml
   when:
     - inventory_hostname == groups[rke2_servers_group_name].0
+    - rke2_ingress_nginx_values is defined
+    - rke2_ingress_nginx_values | length > 0
 
 - name: Prepare very first server node in the cluster
   ansible.builtin.include_tasks: first_server.yml


### PR DESCRIPTION
# Description
Fix for https://github.com/lablabs/ansible-role-rke2/pull/216#issuecomment-2145148007

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
molecule
