### PR TITLE
feat: Add helm chart cilium

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -284,13 +284,7 @@ rke2_ingress_nginx_values: {}
 #        enabled: true
 #      ui:
 #        enabled: true
-rke2_cilium_values: 
-    hubble:
-      enabled: true
-      relay:
-        enabled: true
-      ui:
-        enabled: true
+rke2_cilium_values: {}
         
 # Cordon, drain the node which is being upgraded. Uncordon the node once the RKE2 upgraded
 rke2_drain_node_during_upgrade: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -275,6 +275,23 @@ rke2_agents_group_name: workers
 #       use-forwarded-headers: "true"
 rke2_ingress_nginx_values: {}
 
+# (Optional) Configure cilium via HelmChartConfig: https://docs.rke2.io/networking/basic_network_options#install-a-cni-plugin
+# https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/
+#rke2_cilium_values:
+#    hubble:
+#      enabled: true 
+#      relay:
+#        enabled: true
+#      ui:
+#        enabled: true
+rke2_cilium_values: 
+    hubble:
+      enabled: true
+      relay:
+        enabled: true
+      ui:
+        enabled: true
+        
 # Cordon, drain the node which is being upgraded. Uncordon the node once the RKE2 upgraded
 rke2_drain_node_during_upgrade: false
 

--- a/tasks/cilium.yml
+++ b/tasks/cilium.yml
@@ -1,0 +1,16 @@
+---
+- name: Create the RKE2 manifests directory
+  ansible.builtin.file:
+    state: directory
+    path: "{{ rke2_data_path }}/server/manifests"
+    owner: root
+    group: root
+    mode: 0700
+
+- name: Copy cilium files to first server
+  ansible.builtin.template:
+    src: "templates/cilium-config.yml.j2"
+    dest: "{{ rke2_data_path }}/server/manifests/rke2-cilium-config.yaml"
+    owner: root
+    group: root
+    mode: 0664

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,6 +49,13 @@
     - rke2_ingress_nginx_values is defined
     - rke2_ingress_nginx_values | length > 0
 
+- name: Copy cilium manifests to the masternode
+  ansible.builtin.include_tasks: cilium.yml
+  when:
+    - inventory_hostname == groups[rke2_servers_group_name].0
+    - rke2_cilium_values is defined
+    - rke2_cilium_values | length > 0
+    
 - name: Prepare very first server node in the cluster
   ansible.builtin.include_tasks: first_server.yml
   when:

--- a/templates/cilium-config.yml.j2
+++ b/templates/cilium-config.yml.j2
@@ -1,0 +1,19 @@
+# /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
+# https://docs.rke2.io/networking/basic_network_options
+# https://github.com/rancher/rke2-charts/tree/main/charts/rke2-cilium/rke2-cilium/1.15.600
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-cilium
+  namespace: kube-system
+spec:
+  valuesContent: |-
+{% if rke2_cilium_values | length > 0 %}
+    {{ rke2_cilium_values | to_nice_yaml | indent(2) }}
+{% endif %}
+{% if rke2_ha_mode == true and disable_kube_proxy == true  %}
+    kubeProxyReplacement: true
+    k8sServiceHost: {{ rke2_api_ip }} 
+    k8sServicePort: 6443
+{% endif %}


### PR DESCRIPTION
# Description

It is about add helmchart-config for cilium , the goal is use cilium , then depends the config, but i tested to stop using kube-proxy.

based in
https://docs.rke2.io/networking/basic_network_options
https://github.com/rancher/rke2-charts/blob/main/charts/rke2-cilium/rke2-cilium/1.15.600/values.yaml



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?

i used:

3 pi 4b+  configured 3 master nodes with HA and keepalived 
Ubuntu 24.04 arm64

```
[masters]
master01 ansible_host=192.168.178.60 rke2_type=server
master02 ansible_host=192.168.178.63 rke2_type=server
master03 ansible_host=192.168.178.62 rke2_type=server

[k8s_cluster:children]
masters
```

and 

```

sh-5.2$ cat site.yaml 
- name: Deploy RKE2
  hosts: all
  become: yes
  vars:
    rke2_download_kubeconf_path: "/home/dalmine/.config"
    rke2_ha_mode: true
    rke2_api_ip : 192.168.178.240
    rke2_download_kubeconf: true
    disable_kube_proxy: true
    rke2_cni:
       - cilium
  roles:
     - role: lablabs.rke2

```
Using disalble proxy and ha with api_ip, i also force in the jinja file of cilium another extra parameters where are not in the default/main.yaml 


and
default/main.yml
```
....

rke2_cilium_values:
    hubble:
      enabled: true 
      relay:
        enabled: true
      ui:
        enabled: true

....

```

