### PR TITLE
Don't fail due to missing versions in check mode.

### DIFF
--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -112,6 +112,7 @@
   register: versions_check
 
 - name: Set RKE2 versions
+  when: not ansible_check_mode
   ansible.builtin.set_fact:
     installed_version: "{{ versions.installed_version }}"
     running_version: "{{ versions.running_version }}"
@@ -125,7 +126,7 @@
     INSTALL_RKE2_ARTIFACT_PATH: "{{ rke2_artifact_path }}"
     INSTALL_RKE2_AGENT_IMAGES_DIR: "{{ rke2_data_path }}/agent/images"
   changed_when: false
-  when: rke2_version != installed_version and rke2_airgap_mode
+  when: not ansible_check_mode and rke2_version != installed_version and rke2_airgap_mode
 
 - name: Run RKE2 script
   ansible.builtin.command:
@@ -136,7 +137,7 @@
     INSTALL_RKE2_CHANNEL: "{{ rke2_channel }}"
     INSTALL_RKE2_METHOD: "{{ rke2_method }}"
   changed_when: false
-  when: rke2_version != installed_version and not rke2_airgap_mode
+  when: not ansible_check_mode and rke2_version != installed_version and not rke2_airgap_mode
 
 - name: Copy Custom Manifests
   ansible.builtin.template:


### PR DESCRIPTION
# Description

In check mode, the following failures would occur:

Set RKE2 version:
`{{ versions_check.stdout | from_json }}'. Error was a <class 'json.decoder.JSONDecodeError'>, original message: Expecting value: line 1 column 1 (char 0)"}`

Run AirGap RKE2 script:
`The conditional check 'rke2_version != installed_version and rke2_airgap_mode' failed.`

Run RKE2 script:
`error while evaluating conditional (rke2_version != installed_version and not rke2_airgap_mode): 'installed_version' is undefined.`

Skip those tasks in check mode.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Applied the role locally again with `--check` and no failures this time.