### PR TITLE
fix: Incorrect indentation on config

### DIFF
--- a/templates/registries.yaml.j2
+++ b/templates/registries.yaml.j2
@@ -16,6 +16,6 @@ mirrors:
 configs:
 {% for config in rke2_custom_registry_configs %}
   {{ config.endpoint }}:
-    {{ config.config | to_nice_yaml(indent=6) }}
+    {{ config.config | to_nice_yaml(indent=2) | indent(4) }}
 {%- endfor %}
 {% endif %}


### PR DESCRIPTION
# Description

Fixes YAML indentation issue in registry template when multiple keys are used in config (e.g., auth and tls)
Issue : #241 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Verified the `/etc/rancher/rke2/registries.yaml` file after installation with different values for `rke2_custom_registry_configs`.
