### PR TITLE
Always populate active_server

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,8 +18,6 @@
 
 - name: Find Active Server
   ansible.builtin.include_tasks: find_active_server.yml
-  when:
-    - rke2_ha_mode | bool
 
 - name: Enable IPVS kernel module
   community.general.modprobe:


### PR DESCRIPTION
# Description

Remove condition on `rke2_ha_mode` to always populate active_server fact for fixing #195 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?

- Single master context
  - Execute `ansible-playbook` to create of a single master cluster with `rke2_ha_mode: false`
  - Without any change, execute again `ansible-playbook`
  - No restart of rke2-server service (fix #195)
-Multiple master context
  - Execute `ansible-playbook` to create of a multiple master cluster with `rke2_ha_mode: true`
  - Without any change, execute again `ansible-playbook`
  - No restart of any rke2-server service