### PR TITLE
Update config.yaml.j2

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -6,6 +6,9 @@ server: https://{{ rke2_api_private_ip }}:9345
 server: https://{{ rke2_api_ip }}:9345
 {% endif %}
 {% endif %}
+{% if rke2_bind_address is defined %}
+bind-address: {{ rke2_bind_address }}
+{% endif %}
 {% if rke2_agent_token is defined %}
 agent-token: {{ rke2_agent_token }}
 {% endif %}


### PR DESCRIPTION
added rke2 bind-address to config template

# Description

i have found, that there is no bind-address configuration in config.yaml template, so setting variable  rke2_bind_address takes no effect during rke2 deployment
<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
