### PR TITLE
fix: Change pod readiness check mechanism

### DIFF
--- a/tasks/change_config.yml
+++ b/tasks/change_config.yml
@@ -22,7 +22,7 @@
 - name: Wait for all pods to be ready again
   ansible.builtin.shell: |
     set -o pipefail
-    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get pods -A --field-selector=metadata.namespace!=kube-system | grep -iE "crash|error|init|terminating" | wc -l
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get pods -A --field-selector=metadata.namespace!=kube-system,status.phase!=Running,status.phase!=Succeeded --ignore-not-found | wc -l
   args:
     executable: /bin/bash
   failed_when: "all_pods_ready.rc not in [ 0, 1 ]"

--- a/tasks/change_config.yml
+++ b/tasks/change_config.yml
@@ -25,7 +25,7 @@
     {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get pods -A --field-selector=metadata.namespace!=kube-system,status.phase!=Running,status.phase!=Succeeded --ignore-not-found | wc -l
   args:
     executable: /bin/bash
-  failed_when: "all_pods_ready.rc not in [ 0, 1 ]"
+  failed_when: "all_pods_ready.rc != 0"
   changed_when: false
   register: all_pods_ready
   until:

--- a/tasks/change_config.yml
+++ b/tasks/change_config.yml
@@ -23,10 +23,9 @@
 - name: Wait for all pods to be ready again
   ansible.builtin.shell: |
     set -o pipefail
-    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get pods -A --field-selector=metadata.namespace!=kube-system,status.phase!=Running,status.phase!=Succeeded --ignore-not-found | wc -l
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded --ignore-not-found | wc -l
   args:
     executable: /bin/bash
-  failed_when: "all_pods_ready.rc != 0"
   changed_when: false
   register: all_pods_ready
   until:

--- a/tasks/rolling_restart.yml
+++ b/tasks/rolling_restart.yml
@@ -55,7 +55,7 @@
 - name: Wait for all pods to be ready again
   ansible.builtin.shell: |
     set -o pipefail
-    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get pods -A --field-selector=metadata.namespace!=kube-system | grep -iE "crash|error|init|terminating" | wc -l
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get pods -A --field-selector=metadata.namespace!=kube-system,status.phase!=Running,status.phase!=Succeeded --ignore-not-found | wc -l
   args:
     executable: /bin/bash
   failed_when: "all_pods_ready.rc not in [ 0, 1 ]"

--- a/tasks/rolling_restart.yml
+++ b/tasks/rolling_restart.yml
@@ -58,7 +58,7 @@
     {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get pods -A --field-selector=metadata.namespace!=kube-system,status.phase!=Running,status.phase!=Succeeded --ignore-not-found | wc -l
   args:
     executable: /bin/bash
-  failed_when: "all_pods_ready.rc not in [ 0, 1 ]"
+  failed_when: "all_pods_ready.rc != 0"
   changed_when: false
   register: all_pods_ready
   until:

--- a/tasks/rolling_restart.yml
+++ b/tasks/rolling_restart.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Cordon and Drain the node {{ rke2_node_name }}
   ansible.builtin.shell: |
     set -o pipefail
@@ -55,10 +54,9 @@
 - name: Wait for all pods to be ready again
   ansible.builtin.shell: |
     set -o pipefail
-    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get pods -A --field-selector=metadata.namespace!=kube-system,status.phase!=Running,status.phase!=Succeeded --ignore-not-found | wc -l
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded --ignore-not-found | wc -l
   args:
     executable: /bin/bash
-  failed_when: "all_pods_ready.rc != 0"
   changed_when: false
   register: all_pods_ready
   until:


### PR DESCRIPTION
# Description
If needed i can open an issue for this as well. The following happens:

The check if all pods are ready fails in some of my clusters due to grep catching pods that it is not supposed to, for example:

![image](https://github.com/user-attachments/assets/333c8adc-36da-4893-9e6c-e7c8bc82cd95)

In the situation above i have pods that as part of their name have init, and the check never passes, so i changed it to check the metadata of the pod itself and figure out its phase [https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Tested on Ubuntu 22.04, RKE2 v1.27.12+rke2r1 on a dev cluster and one production cluster where the problems were happening.