### PR TITLE
remove old nodes when restoring etcd

### DIFF
--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -138,15 +138,41 @@
   - not ansible_check_mode
   - rke2_cni != 'none'
 
-- name: Restore etcd - remove old <node>.node-password.rke2 secrets
-  ansible.builtin.shell: |
-    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
-    delete secret {{ item }}.node-password.rke2 -n kube-system 2>&1 || true
-  args:
-    executable: /bin/bash
-  with_items: "{{ groups[rke2_cluster_group_name] }}"
-  changed_when: false
-  when: not ansible_check_mode and inventory_hostname != item and (do_etcd_restore is defined or do_etcd_restore_from_s3 is defined)
+- name: Restore etcd
+  when: do_etcd_restore is defined or do_etcd_restore_from_s3 is defined
+  block:
+    - name: Get registered nodes
+      ansible.builtin.shell: |
+        {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+        get nodes --no-headers | awk '{print $1}'
+      args:
+        executable: /bin/bash
+      changed_when: false
+      register: registered_node_names
+
+    - name: Get all node names
+      ansible.builtin.set_fact:
+        node_names: "{{ hostvars | dict2items | map(attribute='value.rke2_node_name') }}"
+      run_once: true
+      register: node_names
+
+    - name: remove old <node>.node-password.rke2 secrets
+      ansible.builtin.shell: |
+        {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+        delete secret {{ item }}.node-password.rke2 -n kube-system 2>&1 || true
+      args:
+        executable: /bin/bash
+      with_items: "{{ registered_node_names.stdout_lines | difference(node_names) }}"
+      changed_when: false
+
+    - name: remove old nodes
+      ansible.builtin.shell: |
+        {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+        delete node {{ item }} 2>&1 || true
+      args:
+        executable: /bin/bash
+      with_items: "{{ registered_node_names.stdout_lines | difference(node_names) }}"
+      changed_when: false
 
 - name: Set an Active Server variable
   ansible.builtin.set_fact:

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -40,7 +40,13 @@
 - name: Register if we need to do a etcd restore from s3
   ansible.builtin.set_fact:
     do_etcd_restore_from_s3: true
-  when: not rke2_etcd_snapshot_file and rke2_etcd_snapshot_s3_options is defined and rke2_etcd_snapshot_s3_options.access_key and rke2_etcd_snapshot_s3_options.secret_key and rke2_etcd_snapshot_s3_options.bucket and rke2_etcd_snapshot_s3_options.snapshot_name
+  when:
+    - not rke2_etcd_snapshot_file
+    - rke2_etcd_snapshot_s3_options is defined
+    - rke2_etcd_snapshot_s3_options.access_key
+    - rke2_etcd_snapshot_s3_options.secret_key
+    - rke2_etcd_snapshot_s3_options.bucket
+    - rke2_etcd_snapshot_s3_options.snapshot_name
 
 - name: Restore etcd from file
   when: do_etcd_restore is defined


### PR DESCRIPTION
# Description

removes old nodes when restoring etcd

Part of splitting up https://github.com/lablabs/ansible-role-rke2/pull/203

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
