### PR TITLE
make rke2_kubelet_arg set root-dir by default, as the default is unintuitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ rke2_install_bash_url: https://get.rke2.io
 # Local data directory for RKE2
 rke2_data_path: /var/lib/rancher/rke2
 
+# Extra kubelet arguments (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)
+rke2_kubelet_arg:
+    - "root-dir=/var/lib/kubelet" # kubelet data directory (/var/lib/kubelet is the default but "{{ rke2_data_path }}/kubelet" could make more sense for you)
+#   - "system-reserved=cpu=100m,memory=100Mi"
+
 # Default URL to fetch artifacts
 rke2_artifact_url: https://github.com/rancher/rke2/releases/download/
 
@@ -321,10 +326,6 @@ rke2_wait_for_all_pods_to_be_ready: false
 
 # Enable debug mode (rke2-service)
 rke2_debug: false
-
-# (Optional) Customize default kubelet arguments
-# rke2_kubelet_arg:
-#   - "--system-reserved=cpu=100m,memory=100Mi"
 
 # (Optional) Customize default kube-proxy arguments
 # rke2_kube_proxy_arg:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -101,6 +101,12 @@ rke2_install_bash_url: https://get.rke2.io
 # Local data directory for RKE2
 rke2_data_path: /var/lib/rancher/rke2
 
+# Extra kubelet arguments (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)
+rke2_kubelet_arg:
+    - "root-dir=/var/lib/kubelet" # kubelet data directory (/var/lib/kubelet is the default)
+#   - "root-dir={{ rke2_data_path }}/kubelet" # using rke2_data_path could make more sense in your setup.
+#   - "system-reserved=cpu=100m,memory=100Mi"
+
 # Default URL to fetch artifacts
 rke2_artifact_url: https://github.com/rancher/rke2/releases/download/
 
@@ -283,10 +289,6 @@ rke2_wait_for_all_pods_to_be_ready: false
 
 # Enable debug mode (rke2-service)
 rke2_debug: false
-
-# (Optional) Customize default kubelet arguments
-# rke2_kubelet_arg:
-#   - "--system-reserved=cpu=100m,memory=100Mi"
 
 # (Optional) Customize default kube-proxy arguments
 # rke2_kube_proxy_arg:

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -6,7 +6,7 @@
     path: /etc/rancher/rke2
     owner: root
     group: root
-    mode: 075
+    mode: 0755
 
 - name: Set server taints
   ansible.builtin.set_fact:

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -6,7 +6,7 @@
     path: /etc/rancher/rke2
     owner: root
     group: root
-    mode: 0755
+    mode: 075
 
 - name: Set server taints
   ansible.builtin.set_fact:

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -77,12 +77,10 @@ kube-scheduler-arg:
 {% if (rke2_debug | bool ) %}
 debug: true
 {% endif %}
-{% if ( rke2_kubelet_arg is defined ) %}
 kubelet-arg:
 {% for argument in rke2_kubelet_arg %}
   - {{ argument }}
 {% endfor %}
-{% endif %}
 {% if ( rke2_kube_proxy_arg is defined ) %}
 kube-proxy-arg:
 {% for argument in rke2_kube_proxy_arg %}


### PR DESCRIPTION
# Description

make rke2_kubelet_arg set root-dir by default, as the default is unintuitive. This change better indicates that it matters, and makes the default value explicit.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
made the modifications in the rke2 config.yaml and tested if it worked as expected. also rolled out a deployment with this code.
