### PR TITLE
set a random password for keepalived

### DIFF
--- a/tasks/keepalived.yml
+++ b/tasks/keepalived.yml
@@ -20,7 +20,7 @@
     state: directory
     owner: root
     group: root
-    mode: 0755
+    mode: 0750
 
 - name: Create Kubernetes API health check script for Debian OS family
   ansible.builtin.template:
@@ -68,7 +68,7 @@
     dest: /etc/keepalived/keepalived.conf
     owner: root
     group: root
-    mode: 0644
+    mode: 0640
   notify: Restart keepalived
 
 - name: Enable keepalived and make sure it is not masked

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -50,8 +50,8 @@ vrrp_instance VI_1 {
 {% endfor %}
     }
     authentication {
-        auth_type PASS
-        auth_pass rke2servers
+        auth_type AH
+        auth_pass {{ keepalived_secret }}
     }
 ### The following entry is the VRRP config for the incoming interface ###
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,3 +4,4 @@
 rke2_method: tar
 rke2_service_name: "rke2-{{ rke2_type }}.service"
 rke2_restart_needed: false
+keepalived_secret: lookup(community.general.random_string, length=80, base64=True)

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,4 +4,4 @@
 rke2_method: tar
 rke2_service_name: "rke2-{{ rke2_type }}.service"
 rke2_restart_needed: false
-keepalived_secret: "{{ lookup(community.general.random_string, length=80, base64=True) }}"
+keepalived_secret: "{{ lookup('community.general.random_string', length=80, base64=True) }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,4 +4,4 @@
 rke2_method: tar
 rke2_service_name: "rke2-{{ rke2_type }}.service"
 rke2_restart_needed: false
-keepalived_secret: lookup(community.general.random_string, length=80, base64=True)
+keepalived_secret: "{{ lookup(community.general.random_string, length=80, base64=True) }}"


### PR DESCRIPTION
# Description

set a random password for keepalived instead of having the same pre-shared key.
also switched to authentication headers instead of the password, as it is more secure that way.
set the folder permissions so you can't just read the password with OS access.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
