### PR TITLE
fix copying custom manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ rke2_disable_cloud_controller: false
 # applicable only if rke2_disable_cloud_controller is true
 rke2_cloud_provider_name: "external"
 
-# Path to custom manifests deployed during the RKE2 installation
-# It is possible to use Jinja2 templating in the manifests
+# Path to folder with custom manifests deployed during the RKE2 installation
+# It is possible to use Jinja2 templating in the manifests, if the filename ends with .j2
 rke2_custom_manifests:
 
 # Path to static pods deployed during the RKE2 installation

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -155,8 +155,8 @@ rke2_disable_cloud_controller: false
 # applicable only if rke2_disable_cloud_controller is true
 rke2_cloud_provider_name: "external"
 
-# Path to custom manifests deployed during the RKE2 installation
-# It is possible to use Jinja2 templating in the manifests
+# Path to folder with custom manifests deployed during the RKE2 installation
+# It is possible to use Jinja2 templating in the manifests, if the filename ends with .j2
 rke2_custom_manifests:
 
 # Path to static pods deployed during the RKE2 installation

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -142,11 +142,11 @@
 - name: Copy Custom Manifests
   ansible.builtin.template:
     src: "{{ item }}"
-    dest: "{{ rke2_data_path }}/server/manifests/"
+    dest: "{{ rke2_data_path }}/server/manifests/{{ item | basename | replace('.j2', '')}}"
     owner: root
     group: root
-    mode: 0644
-  with_items: "{{ rke2_custom_manifests }}"
+    mode: 0640
+  with_fileglob: "{{ rke2_custom_manifests }}/*"
   when: rke2_custom_manifests
 
 - name: Copy Static Pods
@@ -155,7 +155,7 @@
     dest: "{{ rke2_data_path }}/agent/pod-manifests/"
     owner: root
     group: root
-    mode: 0644
+    mode: 0640
   with_items: "{{ rke2_static_pods }}"
   when: rke2_static_pods
 
@@ -165,5 +165,5 @@
     dest: "/etc/default/rke2-{{ rke2_type }}"
     owner: root
     group: root
-    mode: 0644
+    mode: 0640
   when: rke2_environment_options is defined and rke2_environment_options|length > 0


### PR DESCRIPTION
# Description
Copying custom manifests didn't actually work with j2 templates.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
executed the code and copied a file over