### PR TITLE
Fix RKE2 binary path check

### DIFF
--- a/tasks/cis.yml
+++ b/tasks/cis.yml
@@ -20,7 +20,7 @@
 
 - name: Copy systemctl config file for kernel hardening
   ansible.builtin.copy:
-    src: "{{ '/usr/local/share/rke2/rke2-cis-sysctl.conf' if (usr_local.stat.writeable) and (partition_result.rc == 1) else '/opt/rke2/share/rke2/rke2-cis-sysctl.conf' }}"
+    src: "{{ '/usr/local/share/rke2/rke2-cis-sysctl.conf' if (usr_local.stat.writeable) or (partition_result.rc == 1) else '/opt/rke2/share/rke2/rke2-cis-sysctl.conf' }}"
     dest: /etc/sysctl.d/60-rke2-cis.conf
     mode: 0600
     remote_src: true

--- a/tasks/cis.yml
+++ b/tasks/cis.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Create etcd group
   ansible.builtin.group:
     name: etcd
@@ -13,14 +12,9 @@
     comment: etcd user
     state: present
 
-- name: Check if separate partition
-  ansible.builtin.command: grep '/usr/local ' /proc/mounts
-  changed_when: false
-  register: partition_result
-
 - name: Copy systemctl config file for kernel hardening
   ansible.builtin.copy:
-    src: "{{ '/usr/local/share/rke2/rke2-cis-sysctl.conf' if (usr_local.stat.writeable) or (partition_result.rc == 1) else '/opt/rke2/share/rke2/rke2-cis-sysctl.conf' }}"
+    src: "{{ '/usr/local/share/rke2/rke2-cis-sysctl.conf' if (usr_local.stat.writeable) and (partition_result.rc == 1) else '/opt/rke2/share/rke2/rke2-cis-sysctl.conf' }}"
     dest: /etc/sysctl.d/60-rke2-cis.conf
     mode: 0600
     remote_src: true

--- a/tasks/cis.yml
+++ b/tasks/cis.yml
@@ -14,7 +14,7 @@
 
 - name: Copy systemctl config file for kernel hardening
   ansible.builtin.copy:
-    src: "{{ '/usr/local/share/rke2/rke2-cis-sysctl.conf' if (usr_local.stat.writeable) and (partition_result.rc == 1) else '/opt/rke2/share/rke2/rke2-cis-sysctl.conf' }}"
+    src: "{{ '/usr/local/share/rke2/rke2-cis-sysctl.conf' if (usr_local.stat.writeable) or (partition_result.rc == 1) else '/opt/rke2/share/rke2/rke2-cis-sysctl.conf' }}"
     dest: /etc/sysctl.d/60-rke2-cis.conf
     mode: 0600
     remote_src: true

--- a/tasks/cis.yml
+++ b/tasks/cis.yml
@@ -14,7 +14,8 @@
     state: present
 
 - name: Check if separate partition
-  command: grep '/usr/local ' /proc/mounts
+  ansible.builtin.command: grep '/usr/local ' /proc/mounts
+  changed_when: false
   register: partition_result
 
 - name: Copy systemctl config file for kernel hardening

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Create the RKE2 config dir
   ansible.builtin.file:
     state: directory
@@ -118,15 +117,15 @@
   changed_when: false
   register: node_status
   until:
-  - '"kubelet has sufficient memory available"  in node_status.stdout_lines'
-  - '"kubelet has no disk pressure"  in node_status.stdout_lines'
-  - '"kubelet has sufficient PID available"  in node_status.stdout_lines'
-  - ('"cni plugin not initialized" in node_status.stdout' or '"kubelet is posting ready status." in node_status.stdout')
+    - '"kubelet has sufficient memory available"  in node_status.stdout_lines'
+    - '"kubelet has no disk pressure"  in node_status.stdout_lines'
+    - '"kubelet has sufficient PID available"  in node_status.stdout_lines'
+    - ('"cni plugin not initialized" in node_status.stdout' or '"kubelet is posting ready status." in node_status.stdout')
   retries: 100
   delay: 15
   when:
-  - not ansible_check_mode
-  - rke2_cni == 'none'
+    - not ansible_check_mode
+    - rke2_cni == 'none'
 
 - name: Wait for the first server be ready - with CNI
   ansible.builtin.shell: |
@@ -136,13 +135,12 @@
     executable: /bin/bash
   changed_when: false
   register: first_server
-  until:
-    '" Ready "  in first_server.stdout'
+  until: '" Ready "  in first_server.stdout'
   retries: 40
   delay: 15
   when:
-  - not ansible_check_mode
-  - rke2_cni != 'none'
+    - not ansible_check_mode
+    - rke2_cni != 'none'
 
 - name: Restore etcd
   when: do_etcd_restore is defined or do_etcd_restore_from_s3 is defined
@@ -162,7 +160,7 @@
       run_once: true
       register: node_names
 
-    - name: remove old <node>.node-password.rke2 secrets
+    - name: Remove old <node>.node-password.rke2 secrets
       ansible.builtin.shell: |
         {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
         delete secret {{ item }}.node-password.rke2 -n kube-system 2>&1 || true
@@ -171,7 +169,7 @@
       with_items: "{{ registered_node_names.stdout_lines | difference(node_names) }}"
       changed_when: false
 
-    - name: remove old nodes
+    - name: Remove old nodes
       ansible.builtin.shell: |
         {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
         delete node {{ item }} 2>&1 || true

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -45,7 +45,7 @@
         checksum: "sha256:{{ rke2_artifact_url }}/{{ rke2_version }}/sha256sum-{{ rke2_architecture }}.txt"
         timeout: 30
       with_items: "{{ rke2_artifact | reject('search', 'sha256sum') | list }}"
-    rescue:
+  rescue:
     - name: "Remote downloading failed: Downloading locally and pushing to remote hosts"
       ansible.builtin.pause: # Slight delay to make sure you know it's gonna happen and have time to cancel
         seconds: 7
@@ -122,7 +122,7 @@
     - name: Register artifacts
       ansible.builtin.stat:
         path: "{{ rke2_artifact_path }}/{{ item }}"
-      with_items:  "{{ rke2_artifact }}"
+      with_items: "{{ rke2_artifact }}"
       register: artifacts
     - name: Register install script
       ansible.builtin.stat:
@@ -211,25 +211,25 @@
 - name: Run RKE2 install script
   when: rke2_version != installed_version
   block:
-  - name: Run the script with airgap variables
-    ansible.builtin.command:
-      cmd: "{{ rke2_install_script_dir }}/rke2.sh"
-    environment:
-      INSTALL_RKE2_ARTIFACT_PATH: "{{ rke2_artifact_path }}"
-      INSTALL_RKE2_AGENT_IMAGES_DIR: "{{ rke2_data_path }}/agent/images"
-      INSTALL_RKE2_METHOD: "{{ rke2_method }}"
-    changed_when: false
-    when: rke2_airgap_mode
-  - name: Run RKE2 script without airgap variables
-    ansible.builtin.command:
-      cmd: "{{ rke2_install_script_dir }}/rke2.sh"
-    environment:
-      INSTALL_RKE2_VERSION: "{{ rke2_version }}"
-      INSTALL_RKE2_CHANNEL_URL: "{{ rke2_channel_url }}"
-      INSTALL_RKE2_CHANNEL: "{{ rke2_channel }}"
-      INSTALL_RKE2_METHOD: "{{ rke2_method }}"
-    changed_when: false
-    when: not ansible_check_mode and not rke2_airgap_mode
+    - name: Run the script with airgap variables
+      ansible.builtin.command:
+        cmd: "{{ rke2_install_script_dir }}/rke2.sh"
+      environment:
+        INSTALL_RKE2_ARTIFACT_PATH: "{{ rke2_artifact_path }}"
+        INSTALL_RKE2_AGENT_IMAGES_DIR: "{{ rke2_data_path }}/agent/images"
+        INSTALL_RKE2_METHOD: "{{ rke2_method }}"
+      changed_when: false
+      when: rke2_airgap_mode
+    - name: Run RKE2 script without airgap variables
+      ansible.builtin.command:
+        cmd: "{{ rke2_install_script_dir }}/rke2.sh"
+      environment:
+        INSTALL_RKE2_VERSION: "{{ rke2_version }}"
+        INSTALL_RKE2_CHANNEL_URL: "{{ rke2_channel_url }}"
+        INSTALL_RKE2_CHANNEL: "{{ rke2_channel }}"
+        INSTALL_RKE2_METHOD: "{{ rke2_method }}"
+      changed_when: false
+      when: not ansible_check_mode and not rke2_airgap_mode
 
 - name: Copy Custom Manifests
   ansible.builtin.template:
@@ -244,31 +244,31 @@
 - name: Create /server/manifests directory
   when: rke2_custom_manifests or rke2_static_pods
   block:
-  - name: Create directory
-    ansible.builtin.file:
-      path: "{{ rke2_data_path }}/server/manifests"
-      state: directory
-      mode: 0755
-  - name: Copy Custom Manifests
-    ansible.builtin.template:
-      src: "{{ item }}"
-      dest: "{{ rke2_data_path }}/server/manifests/{{ item | basename | regex_replace('\\.j2$', '') }}"
-      owner: root
-      group: root
-      mode: 0644
-    with_fileglob: "{{ rke2_custom_manifests }}/*"
-    when:
-      - rke2_custom_manifests
-      - inventory_hostname == groups[rke2_servers_group_name].0
-  - name: Copy Static Pods
-    ansible.builtin.copy:
-      src: "{{ item }}"
-      dest: "{{ rke2_data_path }}/agent/pod-manifests/{{ item | basename | regex_replace('\\.j2$', '') }}"
-      owner: root
-      group: root
-      mode: 0644
-    with_fileglob: "{{ rke2_static_pods }}/*"
-    when: rke2_static_pods
+    - name: Create directory
+      ansible.builtin.file:
+        path: "{{ rke2_data_path }}/server/manifests"
+        state: directory
+        mode: 0755
+    - name: Copy Custom Manifests
+      ansible.builtin.template:
+        src: "{{ item }}"
+        dest: "{{ rke2_data_path }}/server/manifests/{{ item | basename | regex_replace('\\.j2$', '') }}"
+        owner: root
+        group: root
+        mode: 0644
+      with_fileglob: "{{ rke2_custom_manifests }}/*"
+      when:
+        - rke2_custom_manifests
+        - inventory_hostname == groups[rke2_servers_group_name].0
+    - name: Copy Static Pods
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: "{{ rke2_data_path }}/agent/pod-manifests/{{ item | basename | regex_replace('\\.j2$', '') }}"
+        owner: root
+        group: root
+        mode: 0644
+      with_fileglob: "{{ rke2_static_pods }}/*"
+      when: rke2_static_pods
 
 - name: Copy RKE2 environment file
   ansible.builtin.template:

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -81,7 +81,7 @@
 
 - name: Set RKE2 bin path
   ansible.builtin.set_fact:
-    rke2_bin_path: "{{ '/usr/local/bin/rke2' if (usr_local.stat.writeable) and (partition_result.rc == 1) else '/opt/rke2/bin/rke2' }}"
+    rke2_bin_path: "{{ '/usr/local/bin/rke2' if (usr_local.stat.writeable) or (partition_result.rc == 1) else '/opt/rke2/bin/rke2' }}"
 
 - name: Check RKE2 version
   ansible.builtin.shell: |

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Download RKE2 installation script
   ansible.builtin.get_url:
     url: "{{ rke2_install_bash_url }}"
@@ -25,21 +24,21 @@
 - name: Download RKE2 checksum and artifacts
   when: rke2_airgap_mode and rke2_airgap_implementation == 'download'
   block:
-  - name: Download sha256 checksum file
-    ansible.builtin.get_url:
-      url: "{{ rke2_artifact_url }}/{{ rke2_version }}/sha256sum-{{ rke2_architecture }}.txt"
-      dest: "{{ rke2_artifact_path }}/sha256sum-{{ rke2_architecture }}.txt"
-      force: yes
-      mode: 0644
-      timeout: 30
-  - name: Download RKE2 artifacts and compare with checksums
-    ansible.builtin.get_url:
-      url: "{{ rke2_artifact_url }}/{{ rke2_version }}/{{ item }}"
-      dest: "{{ rke2_artifact_path }}/{{ item }}"
-      mode: 0644
-      checksum: "sha256:{{ rke2_artifact_url }}/{{ rke2_version }}/sha256sum-{{ rke2_architecture }}.txt"
-      timeout: 30
-    with_items: "{{ rke2_artifact | reject('search', 'sha256sum') | list }}"
+    - name: Download sha256 checksum file
+      ansible.builtin.get_url:
+        url: "{{ rke2_artifact_url }}/{{ rke2_version }}/sha256sum-{{ rke2_architecture }}.txt"
+        dest: "{{ rke2_artifact_path }}/sha256sum-{{ rke2_architecture }}.txt"
+        force: yes
+        mode: 0644
+        timeout: 30
+    - name: Download RKE2 artifacts and compare with checksums
+      ansible.builtin.get_url:
+        url: "{{ rke2_artifact_url }}/{{ rke2_version }}/{{ item }}"
+        dest: "{{ rke2_artifact_path }}/{{ item }}"
+        mode: 0644
+        checksum: "sha256:{{ rke2_artifact_url }}/{{ rke2_version }}/sha256sum-{{ rke2_architecture }}.txt"
+        timeout: 30
+      with_items: "{{ rke2_artifact | reject('search', 'sha256sum') | list }}"
 
 - name: Copy local RKE2 artifacts
   ansible.builtin.copy:
@@ -53,18 +52,18 @@
 - name: Airgap mode - additional images tarballs
   when: rke2_airgap_mode and ( rke2_airgap_copy_additional_tarballs | length > 0 )
   block:
-  - name: Create additional images tarballs folder
-    ansible.builtin.file:
-      path: "{{ rke2_tarball_images_path }}"
-      state: directory
-      mode: 0700
-  - name: Copy additional tarball images RKE2 components
-    ansible.builtin.copy:
-      src: "{{ rke2_airgap_copy_sourcepath }}/{{ item }}"
-      dest: "{{ rke2_tarball_images_path }}/{{ item }}"
-      mode: 0644
-      force: yes
-    with_items: "{{ rke2_airgap_copy_additional_tarballs }}"
+    - name: Create additional images tarballs folder
+      ansible.builtin.file:
+        path: "{{ rke2_tarball_images_path }}"
+        state: directory
+        mode: 0700
+    - name: Copy additional tarball images RKE2 components
+      ansible.builtin.copy:
+        src: "{{ rke2_airgap_copy_sourcepath }}/{{ item }}"
+        dest: "{{ rke2_tarball_images_path }}/{{ item }}"
+        mode: 0644
+        force: yes
+      with_items: "{{ rke2_airgap_copy_additional_tarballs }}"
 
 - name: Populate service facts
   ansible.builtin.service_facts:
@@ -74,9 +73,15 @@
     path: /usr/local
   register: usr_local
 
+- name: Check if separate partition
+  ansible.builtin.command: grep '/usr/local ' /proc/mounts
+  changed_when: false
+  register: partition_result
+  failed_when: partition_result.rc >= 2
+
 - name: Set RKE2 bin path
   ansible.builtin.set_fact:
-    rke2_bin_path: "{{ '/usr/local/bin/rke2' if usr_local.stat.writeable == True else ' /opt/rke2/bin/rke2' }}"
+    rke2_bin_path: "{{ '/usr/local/bin/rke2' if (usr_local.stat.writeable) and (partition_result.rc == 1) else '/opt/rke2/bin/rke2' }}"
 
 - name: Check RKE2 version
   ansible.builtin.shell: |
@@ -112,6 +117,7 @@
   register: versions_check
 
 - name: Set RKE2 versions
+  when: not ansible_check_mode
   ansible.builtin.set_fact:
     installed_version: "{{ versions.installed_version }}"
     running_version: "{{ versions.running_version }}"
@@ -125,7 +131,7 @@
     INSTALL_RKE2_ARTIFACT_PATH: "{{ rke2_artifact_path }}"
     INSTALL_RKE2_AGENT_IMAGES_DIR: "{{ rke2_data_path }}/agent/images"
   changed_when: false
-  when: rke2_version != installed_version and rke2_airgap_mode
+  when: not ansible_check_mode and rke2_version != installed_version and rke2_airgap_mode
 
 - name: Run RKE2 script
   ansible.builtin.command:
@@ -135,8 +141,9 @@
     INSTALL_RKE2_CHANNEL_URL: "{{ rke2_channel_url }}"
     INSTALL_RKE2_CHANNEL: "{{ rke2_channel }}"
     INSTALL_RKE2_METHOD: "{{ rke2_method }}"
+    INSTALL_RKE2_TYPE: "{{ rke2_type }}"
   changed_when: false
-  when: rke2_version != installed_version and not rke2_airgap_mode
+  when: not ansible_check_mode and rke2_version != installed_version and not rke2_airgap_mode
 
 - name: Copy Custom Manifests
   ansible.builtin.template:


### PR DESCRIPTION
# Description

When upgrading a RKE2 cluster which either /usr/local is its own partition or its not writeable then it fails to use the rke2 binary. A similar fix has been made before for the hardening part. This PR moves the partition check to an earlier step and uses the information deciding where the binary is located.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Locally
