### PR TITLE
conditional is missing the and operand

### DIFF
--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -64,4 +64,4 @@
     - '" Ready "  in first_server.stdout'
   retries: 40
   delay: 15
-  when: not ansible_check_mode rke2_cni != 'none'
+  when: not ansible_check_mode and rke2_cni != 'none'


### PR DESCRIPTION
# Description

I was checking the playbook I have (which includes this role) with [little-timmy](https://github.com/hoo29/little-timmy) against unused variables. I got an Jinja2 render error. I realised the error is coming from `and` operand is not present and the conditional is invalid.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
