### PR TITLE
Omit cloud-provider-name if rke_disable_cloud_controller is enabled

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -91,6 +91,8 @@ kube-proxy-arg:
 {% endif %}
 {% if (rke2_disable_cloud_controller | bool ) %}
 disable-cloud-controller: true
+{% endif %}
+{% if not (rke2_disable_cloud_controller | bool ) %}
 cloud-provider-name: "{{ rke2_cloud_provider_name }}"
 {% endif %}
 cluster-cidr: "{% for network in rke2_cluster_cidr %}{{ network }}{% if not loop['last'] %},{% endif %}{% endfor %}"


### PR DESCRIPTION
Otherwise the taint "node.cloudprovider.kubernetes.io/uninitialized" is applied and cluster does not finish setup as nodes are unschedulable.

# Description

Started a test cluster in virtualbox (a.k.a on-prem, 1 master, 1 worker) and there was pending jobs and pods (cluster did not finish setup).

On inspection, the worker was cordoned with "node.cloudprovider.kubernetes.io/uninitialized".



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Deploy into a two-node cluster and check pods afterwards to verify there are no Pending pods (jobs or runtime components).