### PR TITLE
Fix regression when downloading kubeconfig on airgap target

### DIFF
--- a/tasks/summary.yml
+++ b/tasks/summary.yml
@@ -19,8 +19,8 @@
   become: false
   when:
   - not ansible_check_mode
-  - not rke2_airgap_mode
   - rke2_download_kubeconf | bool
+  - inventory_hostname == groups[rke2_servers_group_name].0
 
 - name: Summary
   when: inventory_hostname == groups[rke2_servers_group_name].0


### PR DESCRIPTION
# Description

Since release 1.38.0, a regression appears when downloading kubeconfig on airgap target.
The task "Replace loopback IP by master server IP" is skipped.

Then, the task "Replace loopback IP by master server IP" must be run only once from the first node.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?

With following configuration
```
rke2_airgap_mode: true
rke2_download_kubeconf: true
```

- Run playbook on release 1.37.0 => kubeconfig is downloaded and patched
- Run playbook on release 1.38.0 and 1.38.1 => kubeconfig is downloaded but not patched
