### PR TITLE
Fix ansible_check_mode for 'Run RKE2 install script'

### DIFF
--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -204,9 +204,9 @@
     versions: "{{ versions_check.stdout | from_json }}"
 
 - name: Run RKE2 install script
-  when: rke2_version != installed_version
+  when: not ansible_check_mode and rke2_version != installed_version
   block:
-  - name: Run the script with airgap variables
+  - name: Run RKE2 install script with airgap variables
     ansible.builtin.command:
       cmd: "{{ rke2_install_script_dir }}/rke2.sh"
     environment:
@@ -215,7 +215,7 @@
       INSTALL_RKE2_METHOD: "{{ rke2_method }}"
     changed_when: false
     when: rke2_airgap_mode
-  - name: Run RKE2 script without airgap variables
+  - name: Run RKE2 install script without airgap variables
     ansible.builtin.command:
       cmd: "{{ rke2_install_script_dir }}/rke2.sh"
     environment:
@@ -224,7 +224,7 @@
       INSTALL_RKE2_CHANNEL: "{{ rke2_channel }}"
       INSTALL_RKE2_METHOD: "{{ rke2_method }}"
     changed_when: false
-    when: not ansible_check_mode and not rke2_airgap_mode
+    when: not rke2_airgap_mode
 
 - name: Copy Custom Manifests
   ansible.builtin.template:


### PR DESCRIPTION
# Description

Currently ansible_check_mode fails for Air-gapped setups.
This fixes ansible_check_mode for 'Run RKE2 install script'.
Also update name of the tasks to make it easier to understand what is running.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Tested locally with `--check` mode against a 3 node cluster that is air-gapped.
