### PR TITLE
Revert https://github.com/lablabs/ansible-role-rke2/pull/273

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,9 @@ disable_kube_proxy: false
 # Option to disable builtin cloud controller - mostly for onprem
 rke2_disable_cloud_controller: false
 
-# Cloud provider to use for the cluster (aws, azure, gce, openstack, vsphere, external)
+# Cloud provider to use for the cluster (aws, azure, gce, harvester, rancher-vsphere, openstack, vsphere, external)
 # applicable only if rke2_disable_cloud_controller is true
+# Can be set to false to disable setting it in the configuration file
 rke2_cloud_provider_name: "external"
 
 # Path to custom manifests deployed during the RKE2 installation

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -91,8 +91,6 @@ kube-proxy-arg:
 {% endif %}
 {% if (rke2_disable_cloud_controller | bool ) %}
 disable-cloud-controller: true
-{% endif %}
-{% if not (rke2_disable_cloud_controller | bool ) %}
 cloud-provider-name: "{{ rke2_cloud_provider_name }}"
 {% endif %}
 cluster-cidr: "{% for network in rke2_cluster_cidr %}{{ network }}{% if not loop['last'] %},{% endif %}{% endfor %}"

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -91,7 +91,9 @@ kube-proxy-arg:
 {% endif %}
 {% if (rke2_disable_cloud_controller | bool ) %}
 disable-cloud-controller: true
+{% if rke2_cloud_provider_name != false %}
 cloud-provider-name: "{{ rke2_cloud_provider_name }}"
+{% endif %}
 {% endif %}
 cluster-cidr: "{% for network in rke2_cluster_cidr %}{{ network }}{% if not loop['last'] %},{% endif %}{% endfor %}"
 service-cidr: "{% for network in rke2_service_cidr %}{{ network }}{% if not loop['last'] %},{% endif %}{% endfor %}"


### PR DESCRIPTION
Revert https://github.com/lablabs/ansible-role-rke2/pull/273. It actually does the opposite of what it says it's trying to achieve

# Description
[This](https://github.com/lablabs/ansible-role-rke2/pull/273) achieved the opposite. A brand new cluster gets `node.cloudprovider.kubernetes.io/uninitialized` taint with default settings.

You should remember that `rke2_disable_cloud_controller` is a negative, i.e. when false it enables the RKE2 cloud controller. When true it disables RKE2 cloud controller.

So the code before https://github.com/lablabs/ansible-role-rke2/pull/273 PR was correct.

```jinja2
{% if (rke2_disable_cloud_controller | bool ) %}
disable-cloud-controller: true
cloud-provider-name: "{{ rke2_cloud_provider_name }}"
{% endif %}
```

vs

```jinja2
{% if (rke2_disable_cloud_controller | bool ) %}
disable-cloud-controller: true
{% endif %}
{% if not (rke2_disable_cloud_controller | bool ) %}
cloud-provider-name: "{{ rke2_cloud_provider_name }}"
{% endif %}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Locally on 3 brand new nodes.
