### PR TITLE
Fix not writeable case

### DIFF
--- a/tasks/cis.yml
+++ b/tasks/cis.yml
@@ -14,7 +14,7 @@
 
 - name: Copy systemctl config file for kernel hardening
   ansible.builtin.copy:
-    src: "{{ '/usr/local/share/rke2/rke2-cis-sysctl.conf' if (usr_local.stat.writeable) or (partition_result.rc == 1) else '/opt/rke2/share/rke2/rke2-cis-sysctl.conf' }}"
+    src: "{{ '/usr/local/share/rke2/rke2-cis-sysctl.conf' if (not usr_local.stat.writeable) or (partition_result.rc == 1) else '/opt/rke2/share/rke2/rke2-cis-sysctl.conf' }}"
     dest: /etc/sysctl.d/60-rke2-cis.conf
     mode: 0600
     remote_src: true

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -165,7 +165,7 @@
 
 - name: Set RKE2 bin path
   ansible.builtin.set_fact:
-    rke2_bin_path: "{{ '/usr/local/bin/rke2' if (usr_local.stat.writeable) or (partition_result.rc == 1) else '/opt/rke2/bin/rke2' }}"
+    rke2_bin_path: "{{ '/usr/local/bin/rke2' if (not usr_local.stat.writeable) or (partition_result.rc == 1) else '/opt/rke2/bin/rke2' }}"
 
 - name: Check RKE2 version
   ansible.builtin.shell: |


### PR DESCRIPTION
# Description

The change with #270 made it obvious that the check if the /usr/local path is writeable or not to be invalid. It was missing a negation. Sorry for any issues caused by this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Tested on a hardened RHEL9 cluster which has been reset before deploying the cluster.
