### PR TITLE
fix: remove redundant custom manifests copying

### DIFF
--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -231,16 +231,6 @@
       changed_when: false
       when: not rke2_airgap_mode
 
-- name: Copy Custom Manifests
-  ansible.builtin.template:
-    src: "{{ item }}"
-    dest: "{{ rke2_data_path }}/server/manifests/"
-    owner: root
-    group: root
-    mode: 0644
-  with_items: "{{ rke2_custom_manifests }}"
-  when: rke2_custom_manifests
-
 - name: Create /server/manifests directory
   when: rke2_custom_manifests or rke2_static_pods
   block:


### PR DESCRIPTION
# Description

#285 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
