### PR TITLE
Fix helmchartconfig indent

### DIFF
--- a/templates/ingress-nginx-config.yml.j2
+++ b/templates/ingress-nginx-config.yml.j2
@@ -6,5 +6,5 @@ metadata:
 spec:
   valuesContent: |-
 {% if rke2_ingress_nginx_values | length > 0 %}
-    {{ rke2_ingress_nginx_values | to_nice_yaml | indent(2) }}
+    {{ rke2_ingress_nginx_values | to_nice_yaml(indent=2) | indent(4) }}
 {% endif %}


### PR DESCRIPTION
# Description

This PR fixes indent for HelmChartConfig. While current indent works fine for one-field config, trying to add second dict item will result in only the first being rendered.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?

### Playbook for testing

```yaml
- name: Deploy RKE2
  hosts: k8s_cluster
  become: no
  gather_facts: no
  vars:
    rke2_ingress_nginx_values:
      tcp: 
        "389": "ldap/ldap-prod:389"
      controller: 
        config:
          whitelist-source-range: "192.168.0.0/24"
  tasks:
    - name: copy the output to a local file
      copy:
        content: "{{ lookup('template', 'roles/rke2/templates/ingress-nginx-config.yml.j2') }}"
        dest: "hello.yaml"
      delegate_to: localhost
```

### Run with current template result

Notice `tcp` is outside `valuesContent` block

```yaml
apiVersion: helm.cattle.io/v1
kind: HelmChartConfig
metadata:
  name: rke2-ingress-nginx
  namespace: kube-system
spec:
  valuesContent: |-
    controller:
      config:
          whitelist-source-range: 192.168.0.0/24
  tcp:
      '389': ldap/ldap-prod:389
```

### Run with fixed template result

Now indent is correct for all items

```yaml
apiVersion: helm.cattle.io/v1
kind: HelmChartConfig
metadata:
  name: rke2-ingress-nginx
  namespace: kube-system
spec:
  valuesContent: |-
    controller:
      config:
        whitelist-source-range: 192.168.0.0/24
    tcp:
      '389': ldap/ldap-prod:389
```