### PR TITLE
Added option to configure KubeletConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,15 @@ rke2_wait_for_all_pods_to_be_ready: false
 # Enable debug mode (rke2-service)
 rke2_debug: false
 
+# (Optional) Customize kubelet config using KubeletConfiguration - https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
+# rke2_kubelet_config:
+#   imageGCHighThresholdPercent: 80
+#   imageGCLowThresholdPercent: 70
+# Note that you also need to add the following to kubelet args:
+# rke2_kubelet_arg:
+#   - "--config=/etc/rancher/rke2/kubelet-config.yaml"
+rke2_kubelet_config: {}
+
 # (Optional) Customize default kubelet arguments
 # rke2_kubelet_arg:
 #   - "--system-reserved=cpu=100m,memory=100Mi"
@@ -347,14 +356,6 @@ rke2_service_cidr:
 # Enable SELinux for rke2
 rke2_selinux: false
 
-# (Optional) Customize kubelet config using KubeletConfiguration - https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
-# rke2_kubelet_config:
-#   imageGCHighThresholdPercent: 80
-#   imageGCLowThresholdPercent: 70
-# Note that you also need to add the following to kubelet args:
-# rke2_kubelet_arg:
-#   - "--config=/etc/rancher/rke2/kubelet-config.yaml"
-rke2_kubelet_config: {}
 ```
 
 ## Inventory file example

--- a/README.md
+++ b/README.md
@@ -346,6 +346,15 @@ rke2_service_cidr:
 
 # Enable SELinux for rke2
 rke2_selinux: false
+
+# (Optional) Customize kubelet config using KubeletConfiguration - https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
+# rke2_kubelet_config:
+#   imageGCHighThresholdPercent: 80
+#   imageGCLowThresholdPercent: 70
+# Note that you also need to add the following to kubelet args:
+# rke2_kubelet_arg:
+#   - "--config=/etc/rancher/rke2/kubelet-config.yaml"
+rke2_kubelet_config: {}
 ```
 
 ## Inventory file example

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -313,4 +313,7 @@ rke2_selinux: false
 # rke2_kubelet_config:
 #   imageGCHighThresholdPercent: 80
 #   imageGCLowThresholdPercent: 70
+# Note that you also need to add the following to kubelet args:
+# rke2_kubelet_arg:
+#   - "--config=/etc/rancher/rke2/kubelet-config.yaml"
 rke2_kubelet_config: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -308,3 +308,9 @@ rke2_service_cidr:
 
 # Enable SELinux for rke2
 rke2_selinux: false
+
+# (Optional) Customize kubelet config using KubeletConfiguration - https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
+# rke2_kubelet_config:
+#   imageGCHighThresholdPercent: 80
+#   imageGCLowThresholdPercent: 70
+rke2_kubelet_config: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -287,6 +287,15 @@ rke2_wait_for_all_pods_to_be_ready: false
 # Enable debug mode (rke2-service)
 rke2_debug: false
 
+# (Optional) Customize kubelet config using KubeletConfiguration - https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
+# rke2_kubelet_config:
+#   imageGCHighThresholdPercent: 80
+#   imageGCLowThresholdPercent: 70
+# Note that you also need to add the following to kubelet args:
+# rke2_kubelet_arg:
+#   - "--config=/etc/rancher/rke2/kubelet-config.yaml"
+rke2_kubelet_config: {}
+
 # (Optional) Customize default kubelet arguments
 # rke2_kubelet_arg:
 #   - "--system-reserved=cpu=100m,memory=100Mi"
@@ -308,12 +317,3 @@ rke2_service_cidr:
 
 # Enable SELinux for rke2
 rke2_selinux: false
-
-# (Optional) Customize kubelet config using KubeletConfiguration - https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
-# rke2_kubelet_config:
-#   imageGCHighThresholdPercent: 80
-#   imageGCLowThresholdPercent: 70
-# Note that you also need to add the following to kubelet args:
-# rke2_kubelet_arg:
-#   - "--config=/etc/rancher/rke2/kubelet-config.yaml"
-rke2_kubelet_config: {}

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -21,6 +21,16 @@
     mode: 0600
   notify: "Config file changed"
 
+- name: Copy kubelet config
+  ansible.builtin.template:
+    src: templates/kubelet-config.yaml.j2
+    dest: /etc/rancher/rke2/kubelet-config.yaml
+    owner: root
+    group: root
+    mode: 0600
+  when: rke2_kubelet_config | length > 0
+  notify: "Config file changed"
+
 - name: Copy Containerd Registry Configuration file
   ansible.builtin.template:
     src: "{{ rke2_custom_registry_path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Install Keepalived when HA mode is enabled
   ansible.builtin.include_tasks: keepalived.yml
   when:
@@ -30,7 +29,6 @@
     - rke2_ha_mode | bool
     - rke2_ha_mode_kubevip | bool
     - not rke2_ha_mode_keepalived | bool
-
 
 - name: Copy kube-vip manifests to the masternode
   ansible.builtin.include_tasks: kubevip.yml

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Create the RKE2 config dir
   ansible.builtin.file:
     state: directory
@@ -25,6 +24,16 @@
     owner: root
     group: root
     mode: 0600
+  notify: "Config file changed"
+
+- name: Copy kubelet config
+  ansible.builtin.template:
+    src: templates/kubelet-config.yaml.j2
+    dest: /etc/rancher/rke2/kubelet-config.yaml
+    owner: root
+    group: root
+    mode: 0600
+  when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
 - name: Copy Containerd Registry Configuration file
@@ -85,8 +94,7 @@
     executable: /bin/bash
   changed_when: false
   register: all_ready_nodes
-  until:
-    "groups[rke2_cluster_group_name] | length == all_ready_nodes.stdout | int"
+  until: "groups[rke2_cluster_group_name] | length == all_ready_nodes.stdout | int"
   retries: 100
   delay: 15
   when:

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -17,6 +17,16 @@
     mode: 0600
   notify: "Config file changed"
 
+- name: Copy kubelet config
+  ansible.builtin.template:
+    src: templates/kubelet-config.yaml.j2
+    dest: /etc/rancher/rke2/kubelet-config.yaml
+    owner: root
+    group: root
+    mode: 0600
+  when: rke2_kubelet_config | length > 0
+  notify: "Config file changed"
+
 - name: Copy Containerd Registry Configuration file
   ansible.builtin.template:
     src: "{{ rke2_custom_registry_path }}"

--- a/templates/kubelet-config.yaml.j2
+++ b/templates/kubelet-config.yaml.j2
@@ -1,0 +1,4 @@
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+{{ rke2_kubelet_config | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
# Description
I have the need to pass in kubelet config using KubeletConfiguration - https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
I used this as guidance to achieve this in RKE2 - https://www.suse.com/support/kb/doc/?id=000021322

- Added template for `KubeletConfiguration` that optionaly gets copied to `/etc/rancher/rke2` directory if the variable `rke2_kubelet_config` is populated.
- Added descriptions of the variable + note that in order for the kubelet to use it the following needs to be passed:
```
rke2_kubelet_arg:
  - "--config=/etc/rancher/rke2/kubelet-config.yaml"
```
 
Hope this is something that makes sense to you and is useful :)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Tested on: (RKE2 v1.30.8+rke2r1 + Ubuntu 24.04)
Tested the following scenarios: 
- Creating a fresh cluster
- Adding `rke2_kubelet_config` to an existing cluster 
- Changing `rke2_kubelet_config` on an existing cluster - Added `notify: "Config file changed"` for RKE2 services to restart so that the kubelet picks up new config