### PR TITLE
fix: Prevent version skews when upgrading cluster

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,6 +85,7 @@
     loop_var: _host_item
   when:
     - hostvars[_host_item].inventory_hostname == inventory_hostname
+    - inventory_hostname not in groups[rke2_servers_group_name]
     - installed_version is defined
     - installed_version != "not installed"
     - rke2_version is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,7 +80,7 @@
 
 - name: Rolling cordon and drain restart when version changes - agents
   ansible.builtin.include_tasks: rolling_restart.yml
-  with_items: "{{ groups[rke2_agents_group_name] }}"
+  with_items: "{{ groups[rke2_agents_group_name] | default([]) }}"
   loop_control:
     loop_var: _host_item
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,9 +66,21 @@
     - active_server is defined
     - groups[rke2_cluster_group_name] | length | int >= 2
 
-- name: Rolling cordon and drain restart when version changes
+- name: Rolling cordon and drain restart when version changes - servers
   ansible.builtin.include_tasks: rolling_restart.yml
-  with_items: "{{ groups[rke2_cluster_group_name] }}"
+  with_items: "{{ groups[rke2_servers_group_name] }}"
+  loop_control:
+    loop_var: _host_item
+  when:
+    - hostvars[_host_item].inventory_hostname == inventory_hostname
+    - installed_version is defined
+    - installed_version != "not installed"
+    - rke2_version is defined
+    - rke2_version != running_version
+
+- name: Rolling cordon and drain restart when version changes - agents
+  ansible.builtin.include_tasks: rolling_restart.yml
+  with_items: "{{ groups[rke2_agents_group_name] }}"
   loop_control:
     loop_var: _host_item
   when:


### PR DESCRIPTION
# Description
Hello, 

We have encountered issues when upgrading clusters where agent nodes are upgraded before the API servers, thus violating the Kubernetes [kubelet versioning skew policy](https://kubernetes.io/releases/version-skew-policy/#kubelet) which states:

> `kubelet` must not be newer than `kube-apiserver`.

Combining this violation with the configuration option `rke2_wait_for_all_pods_to_be_ready=true`, the role execution will get stuck and eventually fail as all non-static pods will go into a `CreateContainerConfigError` state with an event from kubelet like:

```
Error: services have not yet been read at least once, cannot construct envvars
```

<!---
Please include a summary of the change and which issue is fixed.
--->

This change ensures that rolling restarts are done on server nodes first to ensure all API servers has been upgraded prior to any agents being restarted to prevent this versioning skew violation.

It is basically a duplicate of the existing `include_task` block for `rolling_restart.yml`, where each block leverages the `rke2_servers_group_name` and `rke2_agents_group_name` for targeting server and agent nodes respectively.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->

This has been tested by uplifting Kubernetes from 1.30.3+rke2r1 to 1.31.4+rke2r1 in a 12-node cluster (3 servers, 9 agents), as well as a smaller cluster with 1 server and 3 agent nodes. After patching the role, all servers were upgraded first, with agents following after, resulting in a successful upgrade with  `rke2_wait_for_all_pods_to_be_ready=true`.