### PR TITLE
add validation to yaml templates

### DIFF
--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -19,7 +19,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -29,7 +29,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -40,7 +40,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   notify: "Config file changed"
 

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -19,7 +19,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -29,7 +29,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -40,7 +40,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   notify: "Config file changed"
 

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -19,7 +19,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -29,7 +29,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -40,7 +40,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   notify: "Config file changed"
 

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -19,6 +19,7 @@
     owner: root
     group: root
     mode: 0600
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -28,6 +29,7 @@
     owner: root
     group: root
     mode: 0600
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -38,6 +40,7 @@
     owner: root
     group: root
     mode: 0600
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   notify: "Config file changed"
 

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -19,7 +19,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -29,7 +29,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -40,7 +40,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   notify: "Config file changed"
 

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -19,7 +19,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python.executable }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -29,7 +29,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python.executable }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -40,7 +40,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python.executable }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   notify: "Config file changed"
 

--- a/tasks/ingress-nginx.yml
+++ b/tasks/ingress-nginx.yml
@@ -14,4 +14,4 @@
     owner: root
     group: root
     mode: 0664
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"

--- a/tasks/ingress-nginx.yml
+++ b/tasks/ingress-nginx.yml
@@ -14,3 +14,4 @@
     owner: root
     group: root
     mode: 0664
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"

--- a/tasks/ingress-nginx.yml
+++ b/tasks/ingress-nginx.yml
@@ -14,4 +14,4 @@
     owner: root
     group: root
     mode: 0664
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"

--- a/tasks/ingress-nginx.yml
+++ b/tasks/ingress-nginx.yml
@@ -14,4 +14,4 @@
     owner: root
     group: root
     mode: 0664
-    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python.executable }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"

--- a/tasks/ingress-nginx.yml
+++ b/tasks/ingress-nginx.yml
@@ -14,4 +14,4 @@
     owner: root
     group: root
     mode: 0664
-    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"

--- a/tasks/ingress-nginx.yml
+++ b/tasks/ingress-nginx.yml
@@ -14,4 +14,4 @@
     owner: root
     group: root
     mode: 0664
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"

--- a/tasks/kubevip.yml
+++ b/tasks/kubevip.yml
@@ -14,7 +14,7 @@
     owner: root
     group: root
     mode: 0664
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   with_fileglob:
     - "templates/kube-vip/kube-vip.yml.j2"
     - "templates/kube-vip/kube-vip-rbac.yml.j2"
@@ -26,7 +26,7 @@
     owner: root
     group: root
     mode: 0664
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   with_fileglob:
     - "templates/kube-vip/kube-vip-cloud-*.j2"
   when:

--- a/tasks/kubevip.yml
+++ b/tasks/kubevip.yml
@@ -14,7 +14,7 @@
     owner: root
     group: root
     mode: 0664
-    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   with_fileglob:
     - "templates/kube-vip/kube-vip.yml.j2"
     - "templates/kube-vip/kube-vip-rbac.yml.j2"
@@ -26,7 +26,7 @@
     owner: root
     group: root
     mode: 0664
-    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   with_fileglob:
     - "templates/kube-vip/kube-vip-cloud-*.j2"
   when:

--- a/tasks/kubevip.yml
+++ b/tasks/kubevip.yml
@@ -14,7 +14,7 @@
     owner: root
     group: root
     mode: 0664
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
   with_fileglob:
     - "templates/kube-vip/kube-vip.yml.j2"
     - "templates/kube-vip/kube-vip-rbac.yml.j2"
@@ -26,7 +26,7 @@
     owner: root
     group: root
     mode: 0664
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
   with_fileglob:
     - "templates/kube-vip/kube-vip-cloud-*.j2"
   when:

--- a/tasks/kubevip.yml
+++ b/tasks/kubevip.yml
@@ -14,7 +14,7 @@
     owner: root
     group: root
     mode: 0664
-    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python.executable }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   with_fileglob:
     - "templates/kube-vip/kube-vip.yml.j2"
     - "templates/kube-vip/kube-vip-rbac.yml.j2"
@@ -26,7 +26,7 @@
     owner: root
     group: root
     mode: 0664
-    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python.executable }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   with_fileglob:
     - "templates/kube-vip/kube-vip-cloud-*.j2"
   when:

--- a/tasks/kubevip.yml
+++ b/tasks/kubevip.yml
@@ -14,7 +14,7 @@
     owner: root
     group: root
     mode: 0664
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
   with_fileglob:
     - "templates/kube-vip/kube-vip.yml.j2"
     - "templates/kube-vip/kube-vip-rbac.yml.j2"
@@ -26,7 +26,7 @@
     owner: root
     group: root
     mode: 0664
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
   with_fileglob:
     - "templates/kube-vip/kube-vip-cloud-*.j2"
   when:

--- a/tasks/kubevip.yml
+++ b/tasks/kubevip.yml
@@ -14,6 +14,7 @@
     owner: root
     group: root
     mode: 0664
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
   with_fileglob:
     - "templates/kube-vip/kube-vip.yml.j2"
     - "templates/kube-vip/kube-vip-rbac.yml.j2"
@@ -25,6 +26,7 @@
     owner: root
     group: root
     mode: 0664
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
   with_fileglob:
     - "templates/kube-vip/kube-vip-cloud-*.j2"
   when:

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -24,7 +24,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -34,7 +34,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -45,7 +45,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   notify: "Config file changed"
 

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -24,7 +24,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python.executable }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -34,7 +34,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python.executable }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -45,7 +45,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python.executable }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   notify: "Config file changed"
 

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -24,7 +24,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -34,7 +34,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -45,7 +45,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   notify: "Config file changed"
 

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -24,7 +24,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -34,7 +34,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -45,7 +45,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   notify: "Config file changed"
 

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -24,7 +24,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -34,7 +34,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -45,7 +45,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   notify: "Config file changed"
 

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -24,6 +24,7 @@
     owner: root
     group: root
     mode: 0600
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -33,6 +34,7 @@
     owner: root
     group: root
     mode: 0600
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -43,6 +45,7 @@
     owner: root
     group: root
     mode: 0600
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
   when: (rke2_custom_registry_mirrors | length > 0 or rke2_custom_registry_configs | length > 0)
   notify: "Config file changed"
 

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -15,7 +15,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -25,7 +25,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -36,7 +36,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_custom_registry_mirrors.0.endpoint | length > 0
   notify: "Config file changed"
 

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -15,7 +15,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -25,7 +25,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -36,7 +36,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_custom_registry_mirrors.0.endpoint | length > 0
   notify: "Config file changed"
 

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -15,6 +15,7 @@
     owner: root
     group: root
     mode: 0600
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -24,6 +25,7 @@
     owner: root
     group: root
     mode: 0600
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -34,6 +36,7 @@
     owner: root
     group: root
     mode: 0600
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
   when: rke2_custom_registry_mirrors.0.endpoint | length > 0
   notify: "Config file changed"
 

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -15,7 +15,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -25,7 +25,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -36,7 +36,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_custom_registry_mirrors.0.endpoint | length > 0
   notify: "Config file changed"
 

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -15,7 +15,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python.executable }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -25,7 +25,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python.executable }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -36,7 +36,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_python_interpreter }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
+    validate: "{{ ansible_python.executable }} -c 'import yaml, sys; sys.tracebacklimit=0; list(yaml.safe_load_all(open(\"%s\").read()))'"
   when: rke2_custom_registry_mirrors.0.endpoint | length > 0
   notify: "Config file changed"
 

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -15,7 +15,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
   notify: "Config file changed"
 
 - name: Copy kubelet config
@@ -25,7 +25,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
   when: rke2_kubelet_config | length > 0
   notify: "Config file changed"
 
@@ -36,7 +36,7 @@
     owner: root
     group: root
     mode: 0600
-    validate: "{{ ansible_playbook_python }} -c 'import yaml; yaml.safe_load(%s)'"
+    validate: "{{ ansible_playbook_python }} -c 'import yaml; list(yaml.safe_load(open(\"%s\").read()))'"
   when: rke2_custom_registry_mirrors.0.endpoint | length > 0
   notify: "Config file changed"
 


### PR DESCRIPTION
# Description

This adds validation to yaml files before copying them to the nodes. The purpose is to ensure that invalid yaml isn't sent to the nodes by accident.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
I tested by running the command like so:

`ansible localhost -m ansible.builtin.template -a '{"src": "./templates/kubelet-config.yaml.j2", "dest": "/home/xxx/test.yaml", "validate": "{{ ansible_playbook_python }} -c \'import yaml; list(yaml.safe_load_all(open(\"%s\").read()))\'"}' -e @./defaults/main.yml`

which returns an error as expected, because the file is not valid yaml without some additional variables. Conversely, it works when the yaml is valid.
