### PR TITLE
allow mirror without endpoint. add nice identation and output

### DIFF
--- a/templates/registries.yaml.j2
+++ b/templates/registries.yaml.j2
@@ -1,23 +1,23 @@
-{%- if rke2_custom_registry_mirrors | length > 0 %}
+{% if rke2_custom_registry_mirrors | length > 0 %}
 mirrors:
-  {%- for mirror in rke2_custom_registry_mirrors %}
+  {% for mirror in rke2_custom_registry_mirrors %}
   "{{ mirror.name }}":
-    {%- if mirror.endpoint is defined %}
+    {% if mirror.endpoint is defined %}
     endpoint:
-      {%- for endpoint in mirror.endpoint %}
+      {% for endpoint in mirror.endpoint %}
       - "{{ endpoint }}"
-      {%- endfor %}
-    {%- endif %}
-    {%- if mirror.rewrite is defined %}
+      {% endfor %}
+    {% endif %}
+    {% if mirror.rewrite is defined %}
     rewrite:
       {{ mirror.rewrite }}
-    {%- endif %}
-  {%- endfor %}
-{%- endif %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
 {% if rke2_custom_registry_configs | length > 0 %}
 configs:
-  {%- for config in rke2_custom_registry_configs %}
+  {% for config in rke2_custom_registry_configs %}
   {{ config.endpoint }}:
     {{ config.config | to_nice_yaml(indent=2) | indent(4) }}
   {%- endfor %}
-{%- endif %}
+{% endif %}

--- a/templates/registries.yaml.j2
+++ b/templates/registries.yaml.j2
@@ -1,21 +1,23 @@
-{% if rke2_custom_registry_mirrors | length > 0 %}
+{%- if rke2_custom_registry_mirrors | length > 0 %}
 mirrors:
-{% for mirror in rke2_custom_registry_mirrors %}
+  {%- for mirror in rke2_custom_registry_mirrors %}
   "{{ mirror.name }}":
+    {%- if mirror.endpoint is defined %}
     endpoint:
-{% for endpoint in mirror.endpoint %}
+      {%- for endpoint in mirror.endpoint %}
       - "{{ endpoint }}"
-{% endfor %}
-{% if mirror.rewrite is defined %}
+      {%- endfor %}
+    {%- endif %}
+    {%- if mirror.rewrite is defined %}
     rewrite:
       {{ mirror.rewrite }}
-{% endif %}
-{% endfor %}
-{% endif %}
+    {%- endif %}
+  {%- endfor %}
+{%- endif %}
 {% if rke2_custom_registry_configs | length > 0 %}
 configs:
-{% for config in rke2_custom_registry_configs %}
+  {%- for config in rke2_custom_registry_configs %}
   {{ config.endpoint }}:
     {{ config.config | to_nice_yaml(indent=2) | indent(4) }}
-{%- endfor %}
-{% endif %}
+  {%- endfor %}
+{%- endif %}


### PR DESCRIPTION
# Description

This lets you make a registry mirror by only defining the name, no endpoints. This is to conform with [RKE2 documentation on enabling the embedded registry mirror.](https://docs.rke2.io/install/registry_mirror#:~:text=The%20%22*%22%20wildcard%20mirror%20entry%20can%20be%20used%20to%20enable%20distributed%20mirroring%20of%20all%20registries)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
using https://j2live.ttl255.com/