### PR TITLE
Allow separate partition check in check mode

### DIFF
--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -181,6 +181,7 @@
   changed_when: false
   register: partition_result
   failed_when: partition_result.rc >= 2
+  check_mode: false
 
 - name: Set RKE2 bin path
   ansible.builtin.set_fact:


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->
This is a read-only operation and later tasks depend on the output leading to check mode failures if it's not executed. With it my playbook finally succeeds in check mode.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
Executed playbook on the cluster in both check mode and normal mode.