### PR TITLE
Secure case of accidental downgrading rke2

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ This is a copy of `defaults/main.yml`
 
 ```yaml
 ---
+# Allow to run rke2 install script if local rke2 version is greater than rke2_variable
+rke2_allow_downgrade: false
+
 # The node type - server or agent
 rke2_type: "{{ 'server' if inventory_hostname in groups[rke2_servers_group_name] else 'agent' if inventory_hostname in groups[rke2_agents_group_name] }}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# Allow to run rke2 install script if local rke2 version is greater than rke2_variable
+rke2_allow_downgrade: false
+
 # The node type - server or agent
 rke2_type: "{{ 'server' if inventory_hostname in groups[rke2_servers_group_name] else 'agent' if inventory_hostname in groups[rke2_agents_group_name] }}"
 

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -14,15 +14,6 @@
   set_fact:
     desired_version_clean: "{{ rke2_version | regex_search('v([0-9]+\\.[0-9]+\\.[0-9]+)(.+)', '\\1') }}"
 
-- name: Debug current_rke2_version
-  debug:
-    var: current_rke2_version
-
-
-- name: Debug rke2_version
-  debug:
-    var:  desired_version_clean
-
 - name: Check condtions
   assert:
     that:

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -1,4 +1,37 @@
 ---
+- name: Check if RKE2 is installed
+  command: rke2 --version
+  register: rke2_version_installed
+  ignore_errors: yes
+
+- name: Set current RKE2 version
+  set_fact:
+    current_rke2_version: "{{ rke2_version_installed.stdout | regex_search('v([0-9]+\\.[0-9]+\\.[0-9]+)(.+)', '\\1') }}"
+  when: rke2_version_installed.rc == 0
+
+
+- name: Set playbook version number
+  set_fact:
+    desired_version_clean: "{{ rke2_version | regex_search('v([0-9]+\\.[0-9]+\\.[0-9]+)(.+)', '\\1') }}"
+
+- name: Debug current_rke2_version
+  debug:
+    var: current_rke2_version
+
+
+- name: Debug rke2_version
+  debug:
+    var:  desired_version_clean
+
+- name: Check condtions
+  assert:
+    that:
+      - current_rke2_version is defined
+      - not rke2_allow_downgrade
+      - current_rke2_version is version(desired_version_clean, '<=')
+    fail_msg: "Current version is greater than or equal to desired version. Skipping installation."
+    success_msg: "Version check passed."
+
 - name: Download RKE2 installation script
   ansible.builtin.get_url:
     url: "{{ rke2_install_bash_url }}"

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -17,12 +17,12 @@
 - name: Check condtions
   assert:
     that:
-      - current_rke2_version is defined
       - >
         (desired_version_clean is version(current_rke2_version, '>=')) or
         (desired_version_clean is version(current_rke2_version, '<') and rke2_allow_downgrade)
     fail_msg: "Current version is greater than or equal to desired version. Skipping installation."
     success_msg: "Version check passed."
+  when: current_rke2_version is defined
 
 - name: Download RKE2 installation script
   ansible.builtin.get_url:

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -9,16 +9,27 @@
     current_rke2_version: "{{ rke2_version_installed.stdout | regex_search('v([0-9]+\\.[0-9]+\\.[0-9]+)(.+)', '\\1') }}"
   when: rke2_version_installed.rc == 0
 
+
 - name: Set playbook version number
   set_fact:
     desired_version_clean: "{{ rke2_version | regex_search('v([0-9]+\\.[0-9]+\\.[0-9]+)(.+)', '\\1') }}"
+
+- name: Debug current_rke2_version
+  debug:
+    var: current_rke2_version
+
+
+- name: Debug rke2_version
+  debug:
+    var:  desired_version_clean
 
 - name: Check condtions
   assert:
     that:
       - current_rke2_version is defined
-      - not rke2_allow_downgrade
-      - current_rke2_version is version(desired_version_clean, '<=')
+      - >
+        (desired_version_clean is version(current_rke2_version, '>=')) or
+        (desired_version_clean is version(current_rke2_version, '<') and rke2_allow_downgrade)
     fail_msg: "Current version is greater than or equal to desired version. Skipping installation."
     success_msg: "Version check passed."
 

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -9,19 +9,9 @@
     current_rke2_version: "{{ rke2_version_installed.stdout | regex_search('v([0-9]+\\.[0-9]+\\.[0-9]+)(.+)', '\\1') }}"
   when: rke2_version_installed.rc == 0
 
-
 - name: Set playbook version number
   set_fact:
     desired_version_clean: "{{ rke2_version | regex_search('v([0-9]+\\.[0-9]+\\.[0-9]+)(.+)', '\\1') }}"
-
-- name: Debug current_rke2_version
-  debug:
-    var: current_rke2_version
-
-
-- name: Debug rke2_version
-  debug:
-    var:  desired_version_clean
 
 - name: Check condtions
   assert:


### PR DESCRIPTION
# Description

If user after initial installation, upgrades cluster with for example rancher, another playbook run will downgrade rke2 version
PR adds condition for checking installed version against rke2_version variable. Although user can set variable rke2_allow_downgrade = true 
for allowing this behavior

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Running gitlab-ci on homelab
- Install version
- change rke2_version variable to lower version
- Run ansible playbook + verify that condition disallowed  - CI stoped before downloading different rke2 version