### PR TITLE
Add additional upgrade options

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,9 +324,17 @@ rke2_ingress_nginx_values: {}
 
 # Cordon, drain the node which is being upgraded. Uncordon the node once the RKE2 upgraded
 rke2_drain_node_during_upgrade: false
+# Additional args that will be passed to the kubectl drain command e.g. --pod-selector
+rke2_drain_additional_args: ""
 
-# Wait for all pods to be ready after rke2-service restart during rolling restart.
+# Wait for all pods to be have a status of running or succeeded after rke2-service restart during rolling restart.
 rke2_wait_for_all_pods_to_be_ready: false
+# Wait for all pods to be ready after rke2-service restart during rolling restart.
+# Named "healthy" to keep backwards compatibility with existing variable names.
+rke2_wait_for_all_pods_to_be_healthy: false
+# The args passed to the kubectl wait command
+rke2_wait_for_all_pods_to_be_healthy_args: --for=condition=Ready -A --all pod --field-selector=metadata.namespace!=kube-system,status.phase!=Succeeded
+
 
 # Enable debug mode (rke2-service)
 rke2_debug: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -286,9 +286,16 @@ rke2_ingress_nginx_values: {}
 
 # Cordon, drain the node which is being upgraded. Uncordon the node once the RKE2 upgraded
 rke2_drain_node_during_upgrade: false
+# Additional args that will be passed to the kubectl drain command e.g. --pod-selector
+rke2_drain_additional_args: ""
 
-# Wait for all pods to be ready after rke2-service restart during rolling restart.
+# Wait for all pods to be have a status of running or succeeded after rke2-service restart during rolling restart.
 rke2_wait_for_all_pods_to_be_ready: false
+# Wait for all pods to be ready after rke2-service restart during rolling restart.
+# Named "healthy" to keep backwards compatibility with existing variable names.
+rke2_wait_for_all_pods_to_be_healthy: false
+# The args passed to the kubectl wait command
+rke2_wait_for_all_pods_to_be_healthy_args: --for=condition=Ready -A --all pod --field-selector=metadata.namespace!=kube-system,status.phase!=Succeeded
 
 # Enable debug mode (rke2-service)
 rke2_debug: false

--- a/tasks/rolling_restart.yml
+++ b/tasks/rolling_restart.yml
@@ -5,7 +5,7 @@
     {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
     cordon "{{ rke2_node_name }}" && \
     {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
-    drain "{{ rke2_node_name }}" --ignore-daemonsets --delete-emptydir-data
+    drain "{{ rke2_node_name }}" --ignore-daemonsets --delete-emptydir-data {{ rke2_drain_additional_args }}
   args:
     executable: /bin/bash
   register: drain
@@ -66,3 +66,15 @@
   delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
   run_once: true
   when: rke2_wait_for_all_pods_to_be_ready
+
+- name: Wait for all pods to pass readiness checks
+  ansible.builtin.shell: |
+    {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml wait {{ rke2_wait_for_all_pods_to_be_healthy_args }}
+  args:
+    executable: /bin/bash
+  changed_when: false
+  retries: 100
+  delay: 15
+  delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
+  run_once: true
+  when: rke2_wait_for_all_pods_to_be_healthy


### PR DESCRIPTION
# Description

Add `rke2_wait_for_all_pods_to_be_healthy` and
`rke2_wait_for_all_pods_to_be_healthy_args`
Currently, the `Wait for all pods to be ready again` task only checks that pods are in the running or succeeded phase, it does not check they are "ready" and passing their health checks. There is now a new task that uses kubectl wait to verify the pods are ready/passing their health checks. To maintain compatibility with current behaviour this is flagged default off with a new var.

Add `rke2_drain_additional_args` to allow args such as --pod-selector to be passed to the drain command. This is helpful for when certain pods such as longhorn-instance-manager don't drain properly.
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Local cluster upgrades
