### PR TITLE
allow supervisor port 9345 override with rke2_api_private_port

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ rke2_ha_mode_kubevip: false
 # Or if the keepalived is disabled, use IP address of your LB.
 rke2_api_ip: "{{ hostvars[groups[rke2_servers_group_name].0]['ansible_default_ipv4']['address'] }}"
 
-# optional option for RKE2 Server to listen on a private IP address on port 9345
+# optional option for RKE2 Server to listen on a private IP address & port
 # rke2_api_private_ip:
+rke2_api_private_port: 9345
 
 # optional option for kubevip IP subnet
 # rke2_api_cidr: 24

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,8 +24,9 @@ rke2_ha_mode_kubevip: false
 # Or if the keepalived is disabled, use IP address of your LB.
 rke2_api_ip: "{{ hostvars[groups[rke2_servers_group_name].0]['ansible_default_ipv4']['address'] }}"
 
-# optional option for RKE2 Server to listen on a private IP address on port 9345
+# optional option for RKE2 Server to listen on a private IP address & port
 # rke2_api_private_ip:
+rke2_api_private_port: 9345
 
 # optional option for kubevip IP subnet
 # rke2_api_cidr: 24

--- a/templates/check_rke2server.sh.j2
+++ b/templates/check_rke2server.sh.j2
@@ -4,6 +4,12 @@ errorExit() {
     exit 1
 }
 curl --silent --max-time 2 --insecure https://localhost:9345/ -o /dev/null || errorExit "Error GET https://localhost:9345/"
+{% if rke2_api_private_ip is defined %}
+if ip addr | grep -wq {{rke2_api_private_ip}}; then
+    curl --silent --max-time 2 --insecure https://{{rke2_api_private_ip}}:{{ rke2_api_private_port }}/ -o /dev/null || errorExit "Error GET https://{{rke2_api_private_ip}}:{{ rke2_api_private_port }}/"
+fi
+{% else %}
 if ip addr | grep -wq {{rke2_api_ip}}; then
     curl --silent --max-time 2 --insecure https://{{rke2_api_ip}}:9345/ -o /dev/null || errorExit "Error GET https://{{rke2_api_ip}}:9345/"
 fi
+{% endif %}

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -1,6 +1,6 @@
 {% if active_server is defined %}
 {% if rke2_api_private_ip is defined %}
-server: https://{{ rke2_api_private_ip }}:9345
+server: https://{{ rke2_api_private_ip }}:{{ rke2_api_private_port }}
 {% else %}
 server: https://{{ rke2_api_ip }}:9345
 {% endif %}


### PR DESCRIPTION
# Description

<!---
I maintaining multiple RKE2 clusters witch are all communication over the same (external) loadbalancer, but on different ports. For this purpose it would be nice where the were an option which allows an overreide of the RKE2 supervisor port (instead of 9345).
--->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
* tested with different supervisor port on an (external) loadbalancer (e.g. 9346 instead of 9345)
--->
