### PR TITLE
Make kubevip params configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ rke2_kubevip_service_election_enable: true
 # this means that every service can end up on a different node when it is created in theory preventing a bottleneck in the initial deployment.
 # minimum kube-vip version 0.5.0
 
+# (Optional) Change parameters for leader election - see upstream install flags link below
+# rke2_kubevip_leaseduration: 5
+# rke2_kubevip_renewdeadline: 3
+# rke2_kubevip_retryperiod: 1
+# rke2_kubevip_loglevel: 4
+
 # (Optional) A list of kube-vip flags
 # All flags can be found here https://kube-vip.io/docs/installation/flags/
 # rke2_kubevip_args: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,6 +64,12 @@ rke2_kubevip_service_election_enable: true
 # this means that every service can end up on a different node when it is created in theory preventing a bottleneck in the initial deployment.
 # minimum kube-vip version 0.5.0
 
+# (Optional) Change parameters for leader election - see upstream install flags link below
+# rke2_kubevip_leaseduration: 5
+# rke2_kubevip_renewdeadline: 3
+# rke2_kubevip_retryperiod: 1
+# rke2_kubevip_loglevel: 4
+
 # (Optional) A list of kube-vip flags
 # All flags can be found here https://kube-vip.io/docs/installation/flags/
 # rke2_kubevip_args: []

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -53,11 +53,13 @@ spec:
         - name: vip_leaderelection
           value: "true"
         - name: vip_leaseduration
-          value: "5"
+          value: "{{ rke2_kubevip_leaseduration | default('5') }}"
         - name: vip_renewdeadline
-          value: "3"
+          value: "{{ rke2_kubevip_renewdeadline | default('3') }}"
         - name: vip_retryperiod
-          value: "1"
+          value: "{{ rke2_kubevip_retryperiod | default('1') }}"
+        - name: vip_loglevel
+          value: "{{ rke2_kubevip_loglevel | default('4') }}"
         - name: address
           value: "{{ rke2_api_ip }}"
         - name: prometheus_server


### PR DESCRIPTION
# Description

Make kube-vip params for leader election and loglevel configurable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Applied on a testing setup. Works as expected.