### PR TITLE
Fix rke2 version for .rke2-wrapped outputs

### DIFF
--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -196,7 +196,7 @@
     rke2_version="{{ rke2_version }}"
 
     if [ -f "$rke2_bin_path" ]; then
-      installed_version="$($rke2_bin_path --version | grep -E "rke2 version" | awk '{print $3}')"
+      installed_version="$($rke2_bin_path --version | awk '/version/ {print $3; exit}')"
     else
       installed_version="not installed"
     fi
@@ -207,7 +207,7 @@
 
     # Linux appends the target of removed proc exe with ' (deleted)', making the path unavailable.
     if [ -f "$rke2_bin_path" ]; then
-      running_version="$($rke2_bin_path --version | grep -E "rke2 version" | awk '{print $3}')"
+      running_version="$($rke2_bin_path --version | awk '/version/ {print $3; exit}')"
     elif [ "$installed_version" = "not installed" ]; then
       running_version="$rke2_version"
     else


### PR DESCRIPTION
# Description

This patch updates the version‐detection logic in the “Check RKE2 version” task so that it correctly parses the output when using the wrapped binary (`.rke2-wrapped`), which prints its header instead of the usual `rke2 version`. It ensures that both the installed and running versions are detected reliably on NixOS and other systems where the binary is wrapped.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
- Applied the patched role locally against a NixOS node with RKE2 installed via Nix (wrapped binary path `/nix/store/.../.rke2-wrapped`).
- Verified that both `installed_version` and `running_version` facts are correctly set to `v1.31.7+rke2r1`.
- Ran full role against a fresh RKE2 cluster in our GitLab CI pipeline and confirmed no failures in “Check RKE2 version” or downstream tasks.