### PR TITLE
fix "rke2_bin_path --version" SIGPIPE error with grep instead of awk

### DIFF
--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -196,7 +196,7 @@
     rke2_version="{{ rke2_version }}"
 
     if [ -f "$rke2_bin_path" ]; then
-      installed_version="$($rke2_bin_path --version | awk '/version/ {print $3; exit}')"
+      installed_version="$($rke2_bin_path --version 2>/dev/null | grep 'rke2 version' | cut -d' ' -f3)"
     else
       installed_version="not installed"
     fi
@@ -207,7 +207,7 @@
 
     # Linux appends the target of removed proc exe with ' (deleted)', making the path unavailable.
     if [ -f "$rke2_bin_path" ]; then
-      running_version="$($rke2_bin_path --version | awk '/version/ {print $3; exit}')"
+      running_version="$($rke2_bin_path --version 2>/dev/null | grep 'rke2 version' | cut -d' ' -f3)"
     elif [ "$installed_version" = "not installed" ]; then
       running_version="$rke2_version"
     else


### PR DESCRIPTION
# Description
Fixes #329 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->

Ran the modified version towards an already running cluster, while previously this task always failed with `rc: 141` after the fix it was working.
