### PR TITLE
Ipv6 improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies
-        run: pip3 install ansible docker molecule molecule-plugins[docker] "requests<2.29.2"
+        run: pip3 install ansible docker molecule molecule-plugins[docker] netaddr "requests<2.29.2"
 
       - name: Run Molecule tests
         run: molecule test
@@ -77,7 +77,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies
-        run: pip3 install ansible docker molecule molecule-plugins[docker] "requests<2.29.2"
+        run: pip3 install ansible docker molecule molecule-plugins[docker] netaddr "requests<2.29.2"
 
       - name: Run Molecule tests
         run: molecule test --scenario-name cluster

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ rke2_ha_mode_kubevip: false
 # Kubernetes API and RKE2 registration IP address. The default Address is the IPv4 of the Server/Master node.
 # In HA mode choose a static IP which will be set as VIP in keepalived.
 # Or if the keepalived is disabled, use IP address of your LB.
-rke2_api_ip: "{{ hostvars[groups[rke2_servers_group_name].0]['ansible_default_ipv4']['address'] }}"
+rke2_api_ip: "{{ hostvars[groups[rke2_servers_group_name].0]['ansible_default_ipv4']['address'] | default(hostvars[groups[rke2_servers_group_name].0]['ansible_default_ipv6']['address'] ) }}"
 
 # optional option for RKE2 Server to listen on a private IP address & port
 # rke2_api_private_ip:

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ rke2_kubevip_cloud_provider_enable: true
 rke2_kubevip_svc_enable: true
 
 # Specify which image is used for kube-vip container
-rke2_kubevip_image: ghcr.io/kube-vip/kube-vip:v0.6.4
+rke2_kubevip_image: ghcr.io/kube-vip/kube-vip:v0.9.2
 
 # Specify which image is used for kube-vip cloud provider container
-rke2_kubevip_cloud_provider_image: ghcr.io/kube-vip/kube-vip-cloud-provider:v0.0.4
+rke2_kubevip_cloud_provider_image: ghcr.io/kube-vip/kube-vip-cloud-provider:v0.0.12
 
 # Enable kube-vip IPVS load balancer for control plane
 rke2_kubevip_ipvs_lb_enable: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,10 +48,10 @@ rke2_kubevip_cloud_provider_enable: true
 rke2_kubevip_svc_enable: true
 
 # Specify which image is used for kube-vip container
-rke2_kubevip_image: ghcr.io/kube-vip/kube-vip:v0.6.4
+rke2_kubevip_image: ghcr.io/kube-vip/kube-vip:v0.9.2
 
 # Specify which image is used for kube-vip cloud provider container
-rke2_kubevip_cloud_provider_image: ghcr.io/kube-vip/kube-vip-cloud-provider:v0.0.4
+rke2_kubevip_cloud_provider_image: ghcr.io/kube-vip/kube-vip-cloud-provider:v0.0.12
 
 # Enable kube-vip IPVS load balancer for control plane
 rke2_kubevip_ipvs_lb_enable: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,7 @@ rke2_ha_mode_kubevip: false
 # Kubernetes API and RKE2 registration IP address. The default Address is the IPv4 of the Server/Master node.
 # In HA mode choose a static IP which will be set as VIP in keepalived.
 # Or if the keepalived is disabled, use IP address of your LB.
-rke2_api_ip: "{{ hostvars[groups[rke2_servers_group_name].0]['ansible_default_ipv4']['address'] }}"
+rke2_api_ip: "{{ hostvars[groups[rke2_servers_group_name].0]['ansible_default_ipv4']['address'] | default(hostvars[groups[rke2_servers_group_name].0]['ansible_default_ipv6']['address'] ) }}"
 
 # optional option for RKE2 Server to listen on a private IP address & port
 # rke2_api_private_ip:

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -84,12 +84,12 @@ argument_specs:
 
       rke2_kubevip_image:
         type: str
-        default: "ghcr.io/kube-vip/kube-vip:v0.6.4"
+        default: "ghcr.io/kube-vip/kube-vip:v0.9.2"
         description: "Specify which image is used for kube-vip container"
 
       rke2_kubevip_cloud_provider_image:
         type: str
-        default: "ghcr.io/kube-vip/kube-vip-cloud-provider:v0.0.4"
+        default: "ghcr.io/kube-vip/kube-vip-cloud-provider:v0.0.12"
         description: "Specify which image is used for kube-vip cloud provider container"
 
       rke2_kubevip_ipvs_lb_enable:

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -39,7 +39,7 @@ argument_specs:
 
       rke2_api_ip:
         type: str
-        default: "{{ hostvars[groups[rke2_servers_group_name].0]['ansible_default_ipv4']['address'] }}"
+        default: "{{ hostvars[groups[rke2_servers_group_name].0]['ansible_default_ipv4']['address'] | default(hostvars[groups[rke2_servers_group_name].0]['ansible_default_ipv6']['address'] ) }}"
         description: "Kubernetes API and RKE2 registration IP address. The default Address is the IPv4 of the Server/Master node. In HA mode choose a static IP which will be set as VIP in keepalived. Or if the keepalived is disabled, use IP address of your LB."
 
       rke2_api_private_ip:

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+collections:
+  - community.general
+  - ansible.utils

--- a/tasks/first_server_restore.yml
+++ b/tasks/first_server_restore.yml
@@ -13,5 +13,5 @@
     delete node {{ item }} 2>&1 || true
   args:
     executable: /bin/bash
-  with_items: "{{ node_names.stdout_lines | difference(groups[rke2_cluster_group_name]) }}"
+  with_items: "{{ node_names.stdout_lines | difference(groups[rke2_cluster_group_name] ) }}"
   changed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,7 +78,7 @@
 
 - name: Rolling cordon and drain restart when version changes - agents
   ansible.builtin.include_tasks: rolling_restart.yml
-  with_items: "{{ groups[rke2_agents_group_name] | default([]) }}"
+  with_items: "{{ groups[rke2_agents_group_name] | default([] ) }}"
   loop_control:
     loop_var: _host_item
   when:

--- a/tasks/summary.yml
+++ b/tasks/summary.yml
@@ -14,7 +14,7 @@
     path: "{{ rke2_download_kubeconf_path }}/{{ rke2_download_kubeconf_file_name }}"
     mode: '0600'
     regexp: '127.0.0.1'
-    replace: "{{ rke2_api_ip | default(hostvars[groups[rke2_servers_group_name].0].ansible_host) }}"
+    replace: "{{ rke2_api_ip | default(hostvars[groups[rke2_servers_group_name].0].ansible_host) | ansible.utils.ipwrap }}"
   delegate_to: localhost
   become: false
   when:

--- a/tasks/summary.yml
+++ b/tasks/summary.yml
@@ -13,7 +13,7 @@
   ansible.builtin.replace:
     path: "{{ rke2_download_kubeconf_path }}/{{ rke2_download_kubeconf_file_name }}"
     mode: '0600'
-    regexp: '127.0.0.1'
+    regexp: '127\.0\.0\.1|\[::1\]'
     replace: "{{ rke2_api_ip | default(hostvars[groups[rke2_servers_group_name].0].ansible_host) | ansible.utils.ipwrap }}"
   delegate_to: localhost
   become: false

--- a/templates/check_apiserver.sh.j2
+++ b/templates/check_apiserver.sh.j2
@@ -3,7 +3,10 @@ errorExit() {
     echo "*** $*" 1>&2
     exit 1
 }
-curl --silent --max-time 2 --insecure https://localhost:{{rke2_apiserver_dest_port}}/healthz --cert {{rke2_data_path}}/server/tls/client-ca.crt --key {{rke2_data_path}}/server/tls/client-ca.key -o /dev/null || errorExit "Error GET https://localhost:{{rke2_apiserver_dest_port}}/healthz"
-if ip addr | grep -wq {{rke2_api_ip}}; then
-    curl --silent --max-time 2 --insecure https://{{rke2_api_ip}}:{{rke2_apiserver_dest_port}}/healthz --cert {{rke2_data_path}}/server/tls/client-ca.crt --key {{rke2_data_path}}/server/tls/client-ca.key -o /dev/null || errorExit "Error GET https://{{rke2_api_ip}}:{{rke2_apiserver_dest_port}}/healthz"
+testUrl() {
+    curl --silent --max-time 2 --insecure "$1" --cert '{{rke2_data_path}}/server/tls/client-ca.crt' --key '{{rke2_data_path}}/server/tls/client-ca.key' -o /dev/null || errorExit "Error GET $1"
+}
+testUrl 'https://localhost:{{rke2_apiserver_dest_port}}/healthz'
+if ip addr | grep -wq '{{rke2_api_ip}}'; then
+    testUrl 'https://{{rke2_api_ip | ansible.utils.ipwrap}}:{{rke2_apiserver_dest_port}}/healthz'
 fi

--- a/templates/check_rke2server.sh.j2
+++ b/templates/check_rke2server.sh.j2
@@ -3,13 +3,16 @@ errorExit() {
     echo "*** $*" 1>&2
     exit 1
 }
-curl --silent --max-time 2 --insecure https://localhost:9345/ -o /dev/null || errorExit "Error GET https://localhost:9345/"
+testUrl() {
+    curl --silent --max-time 2 --insecure "$1" -o /dev/null || errorExit "Error GET $1"
+}
+testUrl https://localhost:9345/
 {% if rke2_api_private_ip is defined %}
-if ip addr | grep -wq {{rke2_api_private_ip}}; then
-    curl --silent --max-time 2 --insecure https://{{rke2_api_private_ip}}:{{ rke2_api_private_port }}/ -o /dev/null || errorExit "Error GET https://{{rke2_api_private_ip}}:{{ rke2_api_private_port }}/"
+if ip addr | grep -wq '{{rke2_api_private_ip}}'; then
+    testUrl 'https://{{rke2_api_private_ip | ansible.utils.ipwrap}}:{{ rke2_api_private_port }}/'
 fi
 {% else %}
-if ip addr | grep -wq {{rke2_api_ip}}; then
-    curl --silent --max-time 2 --insecure https://{{rke2_api_ip}}:9345/ -o /dev/null || errorExit "Error GET https://{{rke2_api_ip}}:9345/"
+if ip addr | grep -wq '{{rke2_api_ip}}'; then
+    testUrl 'https://{{rke2_api_ip | ansible.utils.ipwrap}}:9345/'
 fi
 {% endif %}

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -1,8 +1,8 @@
 {% if active_server is defined %}
 {% if rke2_api_private_ip is defined %}
-server: https://{{ rke2_api_private_ip }}:{{ rke2_api_private_port }}
+server: https://{{ rke2_api_private_ip | ansible.utils.ipwrap }}:{{ rke2_api_private_port }}
 {% else %}
-server: https://{{ rke2_api_ip }}:9345
+server: https://{{ rke2_api_ip | ansible.utils.ipwrap }}:9345
 {% endif %}
 {% endif %}
 {% if rke2_bind_address is defined %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -28,7 +28,7 @@ vrrp_script chk_rke2server {
 }
 
 vrrp_instance VI_1 {
-    interface {{ ansible_default_ipv4.interface }}
+    interface {{ ansible_default_ipv4.interface | default(ansible_default_ipv6.interface) }}
     virtual_router_id 11
 {% if groups[rke2_servers_group_name].0 == inventory_hostname|string() %}
     state MASTER
@@ -41,11 +41,11 @@ vrrp_instance VI_1 {
     {% endif -%}
 {% endfor %}
     advert_int 1
-    unicast_src_ip {{ ansible_default_ipv4.address }}
+    unicast_src_ip {{ ansible_default_ipv4.address | default(ansible_default_ipv6.address) }}
     unicast_peer {
 {% for host in groups[rke2_servers_group_name] %}
 {% if host|string() != inventory_hostname|string() %}
-        {{ hostvars[host]['ansible_default_ipv4']['address'] }}
+        {{ hostvars[host]['ansible_default_ipv4']['address'] | default(hostvars[host]['ansible_default_ipv6']['address'] ) }}
 {% endif %}
 {% endfor %}
     }

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -33,7 +33,7 @@ spec:
         - name: vip_arp
           value: "true"
         - name: vip_interface
-          value: "{{ rke2_interface | default(ansible_default_ipv4.interface) }}"
+          value: "{{ rke2_interface | default(ansible_default_ipv4.interface | default(ansible_default_ipv6.interface)) }}"
         - name: port
           value: "{{ rke2_api_port | default('6443')}}"
         - name: vip_cidr


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->
Improve support for IPv6 deployments.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
  - The kube-vip update surely adds new features as well (but isn't a major update according to semver)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - If you previously set `rke2_api_ip="[2001:db8::1]"`, this will (probably) break now because the brackets are added
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->

Created a IPv6-only cluster with the following values:
```yaml
rke2_version: v1.31.8+rke2r1
rke2_cni:
  - cilium
rke2_cluster_cidr:
  - fd85:1446:b397::/56
rke2_service_cidr:
  - fd85:1446:b397:1000::/112
rke2_api_ip: 2001:db8::10
rke2_download_kubeconf: true
rke2_ha_mode_keepalived: false
rke2_ha_mode_kubevip: true
rke2_loadbalancer_ip_range:
  cidr-global: 2001:db8::1:0/112
rke2_kubevip_ipvs_lb_enable: true
rke2_custom_manifests:
  - templates/rke2-ingress-nginx-config.yaml
```
and the following `templates/rke2-ingress-nginx-config.yaml`:
```yaml
apiVersion: helm.cattle.io/v1
kind: HelmChartConfig
metadata:
  name: rke2-ingress-nginx
  namespace: kube-system
spec:
  valuesContent: |-
    controller:
      service:
        enabled: true
        ipFamilies:
          - IPv6
```