### PR TITLE
fix: #333 get rke2_node_name for only hosts in current cluster inventory group

### DIFF
--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -168,9 +168,7 @@
 
     - name: Get all node names
       ansible.builtin.set_fact:
-        node_names: "{{ hostvars | dict2items | map(attribute='value.rke2_node_name') }}"
-      run_once: true
-      register: node_names
+        node_names: "{{ groups[rke2_cluster_group_name] | map('extract', hostvars) | map(attribute='rke2_node_name') }}"
 
     - name: Remove old <node>.node-password.rke2 secrets
       ansible.builtin.shell: |

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -176,7 +176,7 @@
         delete secret {{ item }}.node-password.rke2 -n kube-system 2>&1 || true
       args:
         executable: /bin/bash
-      with_items: "{{ registered_node_names.stdout_lines | difference(node_names) }}"
+      with_items: "{{ registered_node_names.stdout_lines | difference([rke2_node_name]) }}"
       changed_when: false
 
     - name: Remove old nodes


### PR DESCRIPTION
# Description
This fixes #333 

- The problem was in extracting hostvars by set_fact method which handled all hosts in inventory
- `register: node_names` registered ansible_fact dict so next steps in this block execution were comparing list to dict so were triggered when not needed
```
{'ansible_facts': {'node_names': ['node01', 'node02,  'node03']]}, 'failed': False, 'changed': False}
```


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Created clean nodes and set credentials for s3 restore, then run playbook which invoked role. 
