### PR TITLE
fix: default ingress valsue

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,8 +323,8 @@ rke2_agents_group_name: workers
 # rke2_kube_scheduler_arg:
 #   - "bind-address=0.0.0.0"
 
-# Configure Ingress Controller (allowed values: nginx-ingress, traefik, none)
-rke2_ingress_controller: nginx-ingress
+# Configure Ingress Controller (allowed values: ingress-nginx, traefik, none)
+rke2_ingress_controller: ingress-nginx
 
 # (Optional) Configure nginx via HelmChartConfig: https://docs.rke2.io/networking/networking_services#nginx-ingress-controller
 # rke2_ingress_nginx_values:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -284,8 +284,8 @@ rke2_agents_group_name: workers
 # rke2_kube_scheduler_arg:
 #   - "bind-address=0.0.0.0"
 
-# Configure Ingress Controller (allowed values: nginx-ingress, traefik, none)
-rke2_ingress_controller: nginx-ingress
+# Configure Ingress Controller (allowed values: ingress-nginx, traefik, none)
+rke2_ingress_controller: ingress-nginx
 
 # (Optional) Configure nginx via HelmChartConfig: https://docs.rke2.io/networking/networking_services#nginx-ingress-controller
 # rke2_ingress_nginx_values:


### PR DESCRIPTION
# Description

This PR fixes the default value for `rke2_ingress_controller`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Molecule
