### PR TITLE
When rke2_channel is defined, set rke2_version to the latest version from there

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ rke2_architecture: amd64
 # Destination directory for RKE2 installation script
 rke2_install_script_dir: /var/tmp
 
-# RKE2 channel (overrides rke2_version!)
-rke2_channel: stable
+# RKE2 channel (overrides rke2_version!) - use "stable" or "latest" or a specific version - see https://update.rke2.io/v1-release/channels
+# rke2_channel: stable
 
 # Do not deploy packaged components and delete any deployed components
 # Valid items: rke2-canal, rke2-coredns, rke2-ingress-nginx, rke2-metrics-server

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Role can install the RKE2 in 3 modes:
 ---
 - Additionally it is possible to install the RKE2 Cluster (all 3 modes) in Air-Gapped functionality with the use of local artifacts.
 
-> It is possible to upgrade RKE2 by changing `rke2_version` variable and re-running the playbook with this role. During the upgrade process the RKE2 service on the nodes will be restarted one by one. The Ansible Role will check if the node on which the service was restarted is in Ready state and only then proceed with restarting service on another Kubernetes node.
+> It is possible to upgrade RKE2 by re-running the playbook with this role, using the `rke2_channel` (or `rke2_version`, if `rke2_channel` is not defined). During the upgrade process the RKE2 service on the nodes will be restarted one by one. The Ansible Role will check if the node on which the service was restarted is in Ready state and only then proceed with restarting service on another Kubernetes node.
 
 ## Requirements for Anisble Controller
 
@@ -140,7 +140,7 @@ rke2_agent_node_taints: []
 # Pre-shared secret token that other server or agent nodes will register with when connecting to the cluster
 rke2_token: defaultSecret12345
 
-# RKE2 version
+# RKE2 version (rke2_channel overrides this!)
 rke2_version: v1.25.3+rke2r1
 
 # URL to RKE2 repository
@@ -190,7 +190,7 @@ rke2_architecture: amd64
 # Destination directory for RKE2 installation script
 rke2_install_script_dir: /var/tmp
 
-# RKE2 channel
+# RKE2 channel (overrides rke2_version!)
 rke2_channel: stable
 
 # Do not deploy packaged components and delete any deployed components

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -101,7 +101,7 @@ rke2_agent_node_taints: []
 # Pre-shared secret token that other server or agent nodes will register with when connecting to the cluster
 rke2_token: defaultSecret12345
 
-# RKE2 version
+# RKE2 version (rke2_channel overrides this!)
 rke2_version: v1.25.3+rke2r1
 
 # URL to RKE2 repository
@@ -151,8 +151,8 @@ rke2_architecture: amd64
 # Destination directory for RKE2 installation script
 rke2_install_script_dir: /var/tmp
 
-# RKE2 channel
-rke2_channel: stable
+# RKE2 channel (overrides rke2_version!) - use "stable" or "latest" or a specific version - see https://update.rke2.io/v1-release/channels
+# rke2_channel: stable
 
 # Do not deploy packaged components and delete any deployed components
 # Valid items: rke2-canal, rke2-coredns, rke2-ingress-nginx, rke2-metrics-server

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -231,7 +231,7 @@
     register: rke2_channels_response
   - name: Set latest RKE2 version
     ansible.builtin.set_fact:
-      rke2_version: "{{ rke2_channels_response.json | selectattr('name', 'equalto', rke2_channel) | map(attribute='latest'))[0] }}"
+      rke2_version: "{{ rke2_channels_response.json | selectattr('name', 'equalto', rke2_channel) | map(attribute='latest')[0] }}"
 
 - name: Set RKE2 versions
   when: not ansible_check_mode

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -231,7 +231,7 @@
     register: rke2_channels_response
   - name: Set latest RKE2 version
     ansible.builtin.set_fact:
-      rke2_version: "{{ rke2_channels_response.json | selectattr('name', 'equalto', rke2_channel) | map(attribute='latest')[0] }}"
+      rke2_version: "{{ rke2_channels_response.json | selectattr('name', 'equalto', rke2_channel) | map(attribute='latest') | first }}"
 
 - name: Set RKE2 versions
   when: not ansible_check_mode

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -230,7 +230,7 @@
       url: "{{ rke2_channel_url }}"
       method: GET
       return_content: true
-    register: rke2_channels_resonse
+    register: rke2_channels_response
   - name: Set latest RKE2 version
     ansible.builtin.set_fact:
       rke2_version: "{{ rke2_channels_response.json.data | selectattr('name', 'equalto', rke2_channel) | map(attribute='latest') | first }}"

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -229,7 +229,7 @@
     versions: "{{ versions_check.stdout | from_json }}"
 
 - name: Prevent accidental RKE2 downgrade
-  when: not ansible_check_mode and installed_version != "not installed" and (not rke2_allow_downgrade or (rke2_version is defined and rke2_channel is undefined))
+  when: not ansible_check_mode and installed_version != "not installed" and not rke2_allow_downgrade and (rke2_version is defined and rke2_channel is undefined)
   ansible.builtin.assert:
     that:
       - >

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -220,6 +220,19 @@
   changed_when: false
   register: versions_check
 
+- name: Get latest RKE2 version from channel
+  when: rke2_channel is defined
+  block:
+  - name: Get RKE2 channel json
+    ansible.builtin.uri:
+      url: "{{ rke2_channel_url }}"
+      method: GET
+      return_content: true
+    register: rke2_channels_response
+  - name: Set latest RKE2 version
+    ansible.builtin.set_fact:
+      rke2_version: "{{ rke2_channels_response.json | selectattr('name', 'equalto', rke2_channel) | map(attribute='latest'))[0] }}"
+
 - name: Set RKE2 versions
   when: not ansible_check_mode
   ansible.builtin.set_fact:
@@ -229,7 +242,7 @@
     versions: "{{ versions_check.stdout | from_json }}"
 
 - name: Prevent accidental RKE2 downgrade
-  when: not ansible_check_mode and installed_version != "not installed" and not rke2_allow_downgrade and (rke2_version is defined and rke2_channel is undefined)
+  when: not ansible_check_mode and installed_version != "not installed" and not rke2_allow_downgrade
   ansible.builtin.assert:
     that:
       - >
@@ -248,7 +261,7 @@
     running_version_clean: "{{ running_version | regex_search('v([0-9]+\\.[0-9]+\\.[0-9]+)', '\\1') }}"
 
 - name: Run RKE2 install script
-  when: not ansible_check_mode and ((rke2_version is undefined and rke2_channel is defined) or rke2_version != installed_version)
+  when: not ansible_check_mode and rke2_version != installed_version
   block:
     - name: Run RKE2 install script with airgap variables
       ansible.builtin.command:
@@ -263,7 +276,7 @@
       ansible.builtin.command:
         cmd: "{{ rke2_install_script_dir }}/rke2.sh"
       environment:
-        INSTALL_RKE2_VERSION: "{{ rke2_version }}"
+        INSTALL_RKE2_VERSION: "{{ '' if rke2_channel is defined else rke2_version }}"
         INSTALL_RKE2_CHANNEL_URL: "{{ rke2_channel_url }}"
         INSTALL_RKE2_CHANNEL: "{{ rke2_channel }}"
         INSTALL_RKE2_METHOD: "{{ rke2_method }}"

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -231,7 +231,10 @@
     register: rke2_channels_response
   - name: Set latest RKE2 version
     ansible.builtin.set_fact:
-      rke2_version: "{{ rke2_channels_response.json | selectattr('name', 'equalto', rke2_channel) | map(attribute='latest') | first }}"
+      rke2_version: "{{ rke2_channels_response.json.data | selectattr('name', 'equalto', rke2_channel) | map(attribute='latest') | first }}"
+  - name: Display latest RKE2 version
+    ansible.builtin.debug:
+      msg: "Latest RKE2 version for channel '{{ rke2_channel }}' is '{{ rke2_version }}'"
 
 - name: Set RKE2 versions
   when: not ansible_check_mode

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -224,15 +224,18 @@
   when: rke2_channel is defined
   block:
   - name: Get RKE2 channel json
+    run_once: true
+    delegate_to: localhost
     ansible.builtin.uri:
       url: "{{ rke2_channel_url }}"
       method: GET
       return_content: true
-    register: rke2_channels_response
+    register: rke2_channels_resonse
   - name: Set latest RKE2 version
     ansible.builtin.set_fact:
-      rke2_version: "{{ rke2_channels_response.json.data | selectattr('name', 'equalto', rke2_channel) | map(attribute='latest') | first }}"
+      rke2_version: "{{ hostvars.localhost.rke2_channels_response.json.data | selectattr('name', 'equalto', rke2_channel) | map(attribute='latest') | first }}"
   - name: Display latest RKE2 version
+    run_once: true
     ansible.builtin.debug:
       msg: "Latest RKE2 version for channel '{{ rke2_channel }}' is '{{ rke2_version }}'"
 

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -229,7 +229,7 @@
     versions: "{{ versions_check.stdout | from_json }}"
 
 - name: Prevent accidental RKE2 downgrade
-  when: not ansible_check_mode and installed_version != "not installed" and not rke2_allow_downgrade or (rke2_version is defined and rke2_channel is undefined)
+  when: not ansible_check_mode and installed_version != "not installed" and (not rke2_allow_downgrade or (rke2_version is defined and rke2_channel is undefined))
   ansible.builtin.assert:
     that:
       - >

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -229,7 +229,7 @@
     versions: "{{ versions_check.stdout | from_json }}"
 
 - name: Prevent accidental RKE2 downgrade
-  when: not ansible_check_mode and installed_version != "not installed" and not rke2_allow_downgrade
+  when: not ansible_check_mode and installed_version != "not installed" and not rke2_allow_downgrade or (rke2_version is defined and rke2_channel is undefined)
   ansible.builtin.assert:
     that:
       - >
@@ -248,7 +248,7 @@
     running_version_clean: "{{ running_version | regex_search('v([0-9]+\\.[0-9]+\\.[0-9]+)', '\\1') }}"
 
 - name: Run RKE2 install script
-  when: not ansible_check_mode and rke2_version != installed_version
+  when: not ansible_check_mode and ((rke2_version is undefined and rke2_channel is defined) or rke2_version != installed_version)
   block:
     - name: Run RKE2 install script with airgap variables
       ansible.builtin.command:

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -233,7 +233,7 @@
     register: rke2_channels_resonse
   - name: Set latest RKE2 version
     ansible.builtin.set_fact:
-      rke2_version: "{{ hostvars.localhost.rke2_channels_response.json.data | selectattr('name', 'equalto', rke2_channel) | map(attribute='latest') | first }}"
+      rke2_version: "{{ hostvars['localhost']['rke2_channels_response'].json.data | selectattr('name', 'equalto', rke2_channel) | map(attribute='latest') | first }}"
   - name: Display latest RKE2 version
     run_once: true
     ansible.builtin.debug:

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -233,7 +233,7 @@
     register: rke2_channels_resonse
   - name: Set latest RKE2 version
     ansible.builtin.set_fact:
-      rke2_version: "{{ hostvars['localhost']['rke2_channels_response'].json.data | selectattr('name', 'equalto', rke2_channel) | map(attribute='latest') | first }}"
+      rke2_version: "{{ rke2_channels_response.json.data | selectattr('name', 'equalto', rke2_channel) | map(attribute='latest') | first }}"
   - name: Display latest RKE2 version
     run_once: true
     ansible.builtin.debug:


### PR DESCRIPTION
# Description

Currently, if rke2_channel is defined and rke2_version is undefined (so we use the channel version for updating) then it fails with this error:

```
fatal: [node01]: FAILED! => {"msg": "The conditional check '(rke2_version_clean is version(running_version_clean, '>=')) or (rke2_version_clean is version(running_version_clean, '<') and rke2_allow_downgrade)\n' failed. The error was: Input version value cannot be empty"}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
I ran the code on my own cluster.