### PR TITLE
fix: Allow empty rke2_agents_group_name

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -59,7 +59,7 @@ profile: {{ rke2_cis_profile }}
 {{ option }}
 {% endfor %}
 {% endif %}
-{% if rke2_agent_options is defined and inventory_hostname in groups[rke2_agents_group_name] %}
+{% if rke2_agent_options is defined and inventory_hostname in groups[rke2_agents_group_name] | default([]) %}
 {% for option in rke2_agent_options %}
 {{ option }}
 {% endfor %}


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->
When the agent group specified doesn't exist in the Ansible inventory, the role can still deploy only a control plane.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
Deployed without the `workers` group present in the inventory.