### PR TITLE
add rke2_kube_proxy_extra_mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,10 @@ rke2_kubelet_config: {}
 # rke2_kube_proxy_arg:
 #   - "proxy-mode=ipvs"
 
+# (Optional) Customize default kube-proxy extra mounts
+# rke2_kube_proxy_extra_mount:
+#   - "/lib/modules:/lib/modules:ro"
+
 # The value for the node-name configuration item
 rke2_node_name: "{{ inventory_hostname }}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -331,6 +331,10 @@ rke2_kubelet_config: {}
 # rke2_kube_proxy_arg:
 #   - "proxy-mode=ipvs"
 
+# (Optional) Customize default kube-proxy extra mounts
+# rke2_kube_proxy_extra_mount:
+#   - "/lib/modules:/lib/modules:ro"
+
 # The value for the node-name configuration item
 rke2_node_name: "{{ inventory_hostname }}"
 

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -477,6 +477,13 @@ argument_specs:
         required: false
         description: "Customize default kube-proxy arguments."
 
+      rke2_kube_proxy_extra_mount:
+        type: list
+        default: []
+        elements: str
+        required: false
+        description: "Customize default kube-proxy extra mounts."
+
       rke2_node_name:
         type: str
         default: "{{ inventory_hostname }}"

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -91,6 +91,12 @@ kube-proxy-arg:
   - {{ argument }}
 {% endfor %}
 {% endif %}
+{% if ( rke2_kube_proxy_extra_mount is defined ) %}
+kube-proxy-extra-mount:
+{% for mount in rke2_kube_proxy_extra_mount %}
+  - {{ mount }}
+{% endfor %}
+{% endif %}
 {% if (rke2_disable_cloud_controller | bool ) %}
 disable-cloud-controller: true
 {% if rke2_cloud_provider_name != false %}


### PR DESCRIPTION
# Description

Fixes warning in kube-proxy because of missing mounted host-modules.
`level=warning msg="Running modprobe ip_vs failed with message: modprobe: WARNING: Module ip_vs not found in directory /lib/modules/5.15.0-131-generic, error: exit status 1"`

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Verified with own RKE2 installation
