### PR TITLE
feat: make get_url timeouts configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ rke2_artifact:
   - rke2.linux-{{ rke2_architecture }}.tar.gz
   - rke2-images.linux-{{ rke2_architecture }}.tar.zst
 
+# Timeout for fetching artifacts in seconds
+rke2_artifact_fetch_timeout: 30
+
 # Changes the deploy strategy to install based on local artifacts
 rke2_airgap_mode: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -126,6 +126,9 @@ rke2_artifact:
   - rke2.linux-{{ rke2_architecture }}.tar.gz
   - rke2-images.linux-{{ rke2_architecture }}.tar.zst
 
+# Timeout for fetching artifacts in seconds
+rke2_artifact_fetch_timeout: 30
+
 # Changes the deploy strategy to install based on local artifacts
 rke2_airgap_mode: false
 

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -201,6 +201,11 @@ argument_specs:
         elements: str
         description: "Airgap required artifacts"
 
+      rke2_artifact_fetch_timeout:
+        type: int
+        default: 30
+        description: "Timeout for fetching artifacts in seconds"
+
       rke2_airgap_mode:
         type: bool
         default: false

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -4,6 +4,7 @@
     url: "{{ rke2_install_bash_url }}"
     dest: "{{ rke2_install_script_dir }}/rke2.sh"
     mode: 0700
+    timeout: "{{ rke2_artifact_fetch_timeout }}"
   when: not rke2_airgap_mode
 
 - name: Copy local RKE2 installation script
@@ -36,21 +37,21 @@
         dest: "{{ rke2_artifact_path }}/sha256sum-{{ rke2_architecture }}.txt"
         force: yes
         mode: 0640
-        timeout: 30
+        timeout: "{{ rke2_artifact_fetch_timeout }}"
     - name: Download RKE2 artifacts and compare with checksums ( airgap mode )
       ansible.builtin.get_url:
         url: "{{ rke2_artifact_url }}/{{ rke2_version }}/{{ item }}"
         dest: "{{ rke2_artifact_path }}/{{ item }}"
         mode: 0640
         checksum: "sha256:{{ rke2_artifact_url }}/{{ rke2_version }}/sha256sum-{{ rke2_architecture }}.txt"
-        timeout: 30
+        timeout: "{{ rke2_artifact_fetch_timeout }}"
       with_items: "{{ rke2_artifact | reject('search', 'sha256sum') | list }}"
     - name: Download RKE2 install script ( airgap mode )
       ansible.builtin.get_url:
         url: "{{ rke2_install_bash_url }}"
         dest: "{{ rke2_install_script_dir }}/rke2.sh"
         mode: 0700
-        timeout: 30
+        timeout: "{{ rke2_artifact_fetch_timeout }}"
   rescue:
     - name: "Remote downloading failed: Downloading locally and pushing to remote hosts ( airgap mode - download locally and push to remote )"
       ansible.builtin.pause: # Slight delay to make sure you know it's gonna happen and have time to cancel
@@ -73,7 +74,7 @@
         force: yes
         mode: 0640
         owner: "{{ lookup('env', 'USER') }}"
-        timeout: 30
+        timeout: "{{ rke2_artifact_fetch_timeout }}"
     - name: Downloading RKE2 artifacts locally
       delegate_to: localhost
       run_once: true
@@ -83,6 +84,7 @@
         dest: "{{ rke2_airgap_copy_sourcepath }}/"
         mode: 0640
         owner: "{{ lookup('env', 'USER') }}"
+        timeout: "{{ rke2_artifact_fetch_timeout }}"
       with_items: "{{ [rke2_artifact_url + '/' + rke2_version + '/'] | product(rke2_artifact) | map('join') | list + [rke2_install_bash_url] }}"
     - name: Download RKE2 install script locally
       delegate_to: localhost
@@ -92,6 +94,7 @@
         dest: "{{ rke2_airgap_copy_sourcepath }}/rke2.sh"
         mode: 0700
         owner: "{{ lookup('env', 'USER') }}"
+        timeout: "{{ rke2_artifact_fetch_timeout }}"
     - name: Copy local RKE2 files to remote hosts
       ansible.builtin.copy:
         src: "{{ rke2_airgap_copy_sourcepath }}/"


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->

The `timeout` parameter of all get_url module calls is configurable.
The default for most tasks stays the same as 30 seconds.
Tasks where `timeout` was not explicitely defined before, will change from the [default 10 seconds](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html#parameter-timeout) timeout to 30 seconds.

Fixes: https://github.com/lablabs/ansible-role-rke2/issues/356

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->

Molecule
