### PR TITLE
Add rke2_config_custom_parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,11 @@ rke2_custom_registry_configs: []
 # Path to Container registry config file template
 rke2_custom_registry_path: templates/registries.yaml.j2
 
+# RKE2 config additional custom parameters
+rke2_config_custom_parameters: []
+#  supervisor-metrics: true
+#  embedded-registry: true
+
 # Path to RKE2 config file template
 rke2_config: templates/config.yaml.j2
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -191,6 +191,11 @@ rke2_custom_registry_configs: []
 # Path to Container registry config file template
 rke2_custom_registry_path: templates/registries.yaml.j2
 
+# RKE2 config additional custom parameters
+rke2_config_custom_parameters: []
+#  supervisor-metrics: true
+#  embedded-registry: true
+
 # Path to RKE2 config file template
 rke2_config: templates/config.yaml.j2
 

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -300,6 +300,12 @@ argument_specs:
         default: "templates/registries.yaml.j2"
         description: "Path to Container registry config file template"
 
+      rke2_config_custom_parameters:
+        type: list
+        default: []
+        elements: str
+        description: Configure custom parameters for RKE2 config file
+
       rke2_config:
         type: str
         default: "templates/config.yaml.j2"

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -112,7 +112,5 @@ selinux: true
 ingress-controller: {{ rke2_ingress_controller }}
 {% endif %}
 {% if rke2_config_custom_parameters %}
-{% for key, value in rke2_config_custom_parameters.items() %}
-{{ key }}: {{ value | lower }}
-{% endfor %}
+{{ rke2_config_custom_parameters | to_nice_yaml }}
 {% endif %}

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -105,3 +105,8 @@ selinux: true
 {% if rke2_type == 'server' %}
 ingress-controller: {{ rke2_ingress_controller }}
 {% endif %}
+{% if rke2_config_custom_parameters %}
+{% for key, value in rke2_config_custom_parameters.items() %}
+{{ key }}: {{ value | lower }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
# Description

Adds a custom parameter variable for the RKE2 config file that will apply arbitrary custom parameters to the bottom of the RKE2 config file. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?

This has been tested by deploying with the example parameters shown and with the variable left in the default state to verify it doesn't error out if left empty. I have not had success with extra indented parameters (I think due to a to_nice_yaml bug) so for now I will say it only works with parameters that don't require extra indentation. 
