### PR TITLE
fix: Add missing ansible_check_mode condition in remaining_nodes.yml

### DIFF
--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -83,6 +83,7 @@
   delay: 15
   loop: "{{ groups[rke2_cluster_group_name] }}"
   when:
+    - not ansible_check_mode
     - rke2_cni == 'none'
     - inventory_hostname == active_server or inventory_hostname == groups[rke2_servers_group_name].0
 


### PR DESCRIPTION
# Description

This change adds a missing check-mode guard to the readiness wait tasks. When the role was executed with Ansible check mode (-C), those tasks could enter an infinite loop because the cluster state is not actually changing and the readiness conditions could never be met.

## What’s changed:

- The readiness wait logic is now skipped in check mode, preventing indefinite retries.
- Normal (non-check-mode) runs are unaffected and continue to wait for nodes as expected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?

- Reproduced the hang by running the role with -C before the change.
- Verified that after the change, check-mode runs complete without hanging.
- Confirmed that regular runs still wait for readiness and succeed as before.
