### PR TITLE
feat(rke2): support structured configuration options

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -56,12 +56,24 @@ profile: {{ rke2_cis_profile }}
 {%endif%}
 {% if rke2_server_options is defined and inventory_hostname in groups[rke2_servers_group_name] %}
 {% for option in rke2_server_options %}
+{% if option is mapping %}
+{% for key, value in option.items() %}
+{{ key }}: {{ value }}
+{% endfor %}
+{% else %}
 {{ option }}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% if rke2_agent_options is defined and inventory_hostname in groups[rke2_agents_group_name] | default([]) %}
 {% for option in rke2_agent_options %}
+{% if option is mapping %}
+{% for key, value in option.items() %}
+{{ key }}: {{ value }}
+{% endfor %}
+{% else %}
 {{ option }}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% if ( rke2_kube_controller_manager_arg is defined ) %}

--- a/templates/rke2_environment.j2
+++ b/templates/rke2_environment.j2
@@ -1,3 +1,9 @@
 {% for option in rke2_environment_options %}
+{% if option is mapping %}
+{% for key, value in option.items() %}
+{{ key }}: {{ value }}
+{% endfor %}
+{% else %}
 {{ option }}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
- Add conditional handling for mapping-type options
- Enable key-value pair rendering for server options
- Enable key-value pair rendering for agent options
- Enable key-value pair rendering for environment options
- Maintain backward compatibility with string options
- Improve template logic for configuration generation

# Description

<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->

The original syntax is list string (doc <https://github.com/lablabs/ansible-role-rke2/blob/main/README.md?plain=1#L301-L317>)

```yaml
# e.g. 
rke2_server_options:
  - "option: value"
rke2_agent_options:
  - "option: value"
rke2_environment_options:
  - "option: value"
```

The new syntax support list string and list object

```yaml
# e.g.
rke2_server_options:
  - "option1: value"
  - option2: value2
```