### PR TITLE
feat: RKE2 etcd object storage configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,11 +257,15 @@ rke2_etcd_snapshot_destination_dir: "{{ rke2_data_path }}/server/db/snapshots"
   # access_key: "" # required
   # secret_key: "" # required
   # bucket: "" # required
-  # snapshot_name: "" # required.
+  # snapshot_name: "" # optional - if specified, etcd will be restored upon the first initialization, that is, when starting from a clean slate
   # skip_ssl_verify: false # optional
   # endpoint_ca: "" # optional. Can skip if using defaults
   # region: "" # optional - defaults to us-east-1
   # folder: "" # optional - defaults to top level of bucket
+  # proxy: "" # optional - Proxy server to use when connecting to S3, overriding any proxy-related environment variables
+  # insecure: false # optional - Disables S3 over HTTPS
+  # timeout: "" # optional - S3 timeout (default: 5m0s)
+  # s3_retention: 5 # optional - Number of snapshots in S3 to retain (default: 5)
 # Override default containerd snapshotter
 rke2_snapshotter: "{{ rke2_snapshooter }}"
 rke2_snapshooter: overlayfs # legacy variable that only exists to keep backward compatibility with previous configurations

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -218,15 +218,20 @@ rke2_etcd_snapshot_destination_dir: "{{ rke2_data_path }}/server/db/snapshots"
 # Set either all these values or `rke2_etcd_snapshot_file` and `rke2_etcd_snapshot_source_dir`
 
 # rke2_etcd_snapshot_s3_options:
+  # https://docs.rke2.io/datastore/backup_restore?_highlight=restore&_highlight=sna&etcdsnap=Multiple+Servers#s3-compatible-object-store-support
   # s3_endpoint: "" # required
   # access_key: "" # required
   # secret_key: "" # required
   # bucket: "" # required
-  # snapshot_name: "" # required.
+  # snapshot_name: "" # optional - if specified, etcd will be restored upon the first initialization, that is, when starting from a clean slate
   # skip_ssl_verify: false # optional
-  # endpoint_ca: "" # optional. Can skip if using defaults
+  # endpoint_ca: "" # optional
   # region: "" # optional - defaults to us-east-1
   # folder: "" # optional - defaults to top level of bucket
+  # proxy: "" # optional - Proxy server to use when connecting to S3, overriding any proxy-related environment variables
+  # insecure: false # optional - Disables S3 over HTTPS
+  # timeout: "" # optional - S3 timeout (default: 5m0s)
+  # s3_retention: 5 # optional - Number of snapshots in S3 to retain (default: 5)
 # Override default containerd snapshotter
 rke2_snapshotter: "{{ rke2_snapshooter }}"
 rke2_snapshooter: overlayfs # legacy variable that only exists to keep backward compatibility with previous configurations

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -47,6 +47,45 @@ snapshotter: {{ rke2_snapshotter }}
 {% if rke2_etcd_snapshot_schedule is defined %}
 etcd-snapshot-schedule-cron: "{{ rke2_etcd_snapshot_schedule }}"
 {% endif %}
+{% if rke2_etcd_snapshot_s3_options is defined %}
+etcd-s3: true
+{% if rke2_etcd_snapshot_s3_options.s3_endpoint is defined %}
+etcd-s3-endpoint: {{ rke2_etcd_snapshot_s3_options.s3_endpoint }}
+{% endif %}
+{% if rke2_etcd_snapshot_s3_options.endpoint_ca is defined %}
+etcd-s3-endpoint-ca: {{ rke2_etcd_snapshot_s3_options.endpoint_ca }}
+{% endif %}
+{% if rke2_etcd_snapshot_s3_options.skip_ssl_verify is defined %}
+etcd-s3-skip-ssl-verify: {{ rke2_etcd_snapshot_s3_options.skip_ssl_verify }}
+{% endif %}
+{% if rke2_etcd_snapshot_s3_options.access_key is defined %}
+etcd-s3-access-key: {{ rke2_etcd_snapshot_s3_options.access_key }}
+{% endif %}
+{% if rke2_etcd_snapshot_s3_options.secret_key is defined %}
+etcd-s3-secret-key: {{ rke2_etcd_snapshot_s3_options.secret_key }}
+{% endif %}
+{% if rke2_etcd_snapshot_s3_options.bucket is defined %}
+etcd-s3-bucket: {{ rke2_etcd_snapshot_s3_options.bucket }}
+{% endif %}
+{% if rke2_etcd_snapshot_s3_options.region is defined %}
+etcd-s3-region: {{ rke2_etcd_snapshot_s3_options.region }}
+{% endif %}
+{% if rke2_etcd_snapshot_s3_options.folder is defined %}
+etcd-s3-folder: {{ rke2_etcd_snapshot_s3_options.folder }}
+{% endif %}
+{% if rke2_etcd_snapshot_s3_options.proxy is defined %}
+etcd-s3-proxy: {{ rke2_etcd_snapshot_s3_options.proxy }}
+{% endif %}
+{% if rke2_etcd_snapshot_s3_options.insecure is defined %}
+etcd-s3-insecure: {{ rke2_etcd_snapshot_s3_options.insecure }}
+{% endif %}
+{% if rke2_etcd_snapshot_s3_options.timeout is defined %}
+etcd-s3-timeout: {{ rke2_etcd_snapshot_s3_options.timeout }}
+{% endif %}
+{% if rke2_etcd_snapshot_s3_options.s3_retention is defined %}
+etcd-s3-retention: {{ rke2_etcd_snapshot_s3_options.s3_retention | default(5) }}
+{% endif %}
+{% endif %}
 node-name: {{ rke2_node_name }}
 {% if ( disable_kube_proxy | bool ) %}
 disable-kube-proxy: true


### PR DESCRIPTION
# Description

Building upon prior work[^1], this adds the configuration options for persisting snapshots to object storage as per the [docs](https://docs.rke2.io/datastore/backup_restore?_highlight=restore&_highlight=sna&etcdsnap=Multiple+Servers#s3-compatible-object-store-support).

[^1]: up to now, "only" restoring from etcd snapshot@S3 was possible.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Manual execution and cross-checking the object store.
