### PR TITLE
fix: Correct artifacts_writeable calculation for airgap exists mode

### DIFF
--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -152,7 +152,14 @@
       register: install_script
     - name: Register artifact facts
       ansible.builtin.set_fact:
-        artifacts_writeable: "{{ artifacts.values() | map(attribute='writeable') | list | bool }}"
+        artifacts_writeable: >-
+          {{
+            (artifacts.results
+             | map(attribute='stat.writeable')
+             | select('equalto', true)
+             | list
+             | length) > 0
+          }}
     - name: Make the artifacts read-only
       ansible.builtin.file:
         path: "{{ rke2_artifact_path }}/{{ item }}"


### PR DESCRIPTION
# Description

The airgap "exists" workflow registers artifact stats into `artifacts.results`, but the previous template iterated over `artifacts.values()` and attempted to read `writeable` from non-mapping values (e.g. the `results` list), which could crash with: "object of type 'list' has no attribute 'writeable'".

Compute artifacts_writeable from `artifacts.results[*].stat.writeable` instead, avoiding the invalid access and allowing the role to proceed.

Fixes #380

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?

- Tested on: Ansible 2.20.1, Python 3.12.9
- Scenario: `rke2_airgap_mode=true`, `rke2_airgap_implementation=exists`
- Result: no failure in "Register artifact facts", playbook completes