### PR TITLE
Adding customizable defaults to kube-vip template. Add support for valueFrom in rke2_kubevip_args.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ rke2_kubevip_cp_enable: true
 rke2_kubevip_cp_namespace: "kube-system"
 
 # Enable kube-vip DDNS for control plane load balancer
-rke2_kubevip_ddns_enable: falseEnable kube-vip control plane load balancer to use unicast instead of ARP
+rke2_kubevip_ddns_enable: false
 
 # Enable kube-vip UPnP for control plane load balancer
 rke2_kubevip_upnp_enable: false

--- a/README.md
+++ b/README.md
@@ -121,6 +121,24 @@ rke2_kubevip_service_election_enable: true
 # Prometheus metrics port for kube-vip
 rke2_kubevip_metrics_port: 2112
 
+# Enable ARP for kube-vip load balancer
+rke2_kubevip_arp_enable: true
+
+# Enable kube-vip control plane load balancer for RKE2
+rke2_kubevip_cp_enable: true
+
+# Namespace for kube-vip control plane load balancer
+rke2_kubevip_cp_namespace: "kube-system"
+
+# Enable kube-vip DDNS for control plane load balancer
+rke2_kubevip_ddns_enable: falseEnable kube-vip control plane load balancer to use unicast instead of ARP
+
+# Enable kube-vip UPnP for control plane load balancer
+rke2_kubevip_upnp_enable: false
+
+# Enable kube-vip leader election for control plane load balancer
+rke2_kubevip_leaderelection_enable: true
+
 # Add additional SANs in k8s API TLS cert
 rke2_additional_sans: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,7 +92,7 @@ rke2_kubevip_cp_enable: true
 rke2_kubevip_cp_namespace: "kube-system"
 
 # Enable kube-vip DDNS for control plane load balancer
-rke2_kubevip_ddns_enable: falseEnable kube-vip control plane load balancer to use unicast instead of ARP
+rke2_kubevip_ddns_enable: false
 
 # Enable kube-vip UPnP for control plane load balancer
 rke2_kubevip_upnp_enable: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,6 +82,24 @@ rke2_kubevip_service_election_enable: true
 # Prometheus metrics port for kube-vip
 rke2_kubevip_metrics_port: 2112
 
+# Enable ARP for kube-vip load balancer
+rke2_kubevip_arp_enable: true
+
+# Enable kube-vip control plane load balancer for RKE2
+rke2_kubevip_cp_enable: true
+
+# Namespace for kube-vip control plane load balancer
+rke2_kubevip_cp_namespace: "kube-system"
+
+# Enable kube-vip DDNS for control plane load balancer
+rke2_kubevip_ddns_enable: falseEnable kube-vip control plane load balancer to use unicast instead of ARP
+
+# Enable kube-vip UPnP for control plane load balancer
+rke2_kubevip_upnp_enable: false
+
+# Enable kube-vip leader election for control plane load balancer
+rke2_kubevip_leaderelection_enable: true
+
 # Add additional SANs in k8s API TLS cert
 rke2_additional_sans: []
 

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -133,6 +133,36 @@ argument_specs:
         default: 2112
         description: "Prometheus metrics port for kube-vip"
 
+      rke2_kubevip_arp_enable:
+        type: bool
+        default: true
+        description: "Enable ARP for kube-vip"
+
+      rke2_kubevip_cp_enable:
+        type: bool
+        default: true
+        description: "Enable kube-vip control plane load balancer"
+
+      rke2_kubevip_cp_namespace:
+        type: str
+        default: "kube-system"
+        description: "Namespace for kube-vip control plane load balancer"
+
+      rke2_kubevip_ddns_enable:
+        type: bool
+        default: false
+        description: "Enable kube-vip DDNS functionality"
+
+      rke2_kubevip_upnp_enable:
+        type: bool
+        default: false
+        description: "Enable kube-vip UPnP functionality"
+
+      rke2_kubevip_leaderelection_enable:
+        type: bool
+        default: true
+        description: "Enable kube-vip leader election"
+
       rke2_additional_sans:
         type: list
         default: []

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -31,7 +31,7 @@ spec:
         - manager
         env:
         - name: vip_arp
-          value: "true"
+          value: "{{ rke2_kubevip_arp_enable | default('true') }}"
         - name: vip_nodename
           valueFrom:
             fieldRef:
@@ -43,19 +43,19 @@ spec:
         - name: vip_cidr
           value: "{{ rke2_api_cidr | default('24') }}"
         - name: cp_enable
-          value: "true"
+          value: "{{ rke2_kubevip_cp_enable | default('true') }}"
         - name: cp_namespace
-          value: kube-system
+          value: "{{ rke2_kubevip_cp_namespace | default('kube-system') }}"
         - name: vip_ddns
-          value: "false"
+          value: "{{ rke2_kubevip_ddns_enable | default('false') }}"
         - name: enableUPNP
-          value: "false"
+          value: "{{ rke2_kubevip_upnp_enable | default('false') }}"
         - name: svc_enable
           value: "{{ rke2_kubevip_svc_enable }}"
         - name: svc_election
           value: "{{ rke2_kubevip_service_election_enable }}"
         - name: vip_leaderelection
-          value: "true"
+          value: "{{ rke2_kubevip_leaderelection_enable | default('true') }}"
         - name: vip_leaseduration
           value: "{{ rke2_kubevip_leaseduration | default('5') }}"
         - name: vip_renewdeadline
@@ -73,7 +73,12 @@ spec:
 {% if rke2_kubevip_args  is defined %}
 {% for item in rke2_kubevip_args %}
         - name: {{ item.param }}
+          {%if item.value is defined %}
           value: {{ item.value }}
+          {% endif %}
+          {%if item.valueFrom is defined %}
+          valueFrom: {{ item.valueFrom }}
+          {% endif %}
 {% endfor %}
 {% endif %}
         image: "{{ rke2_kubevip_image }}"

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -74,12 +74,11 @@ spec:
 {% for item in rke2_kubevip_args %}
         - name: {{ item.param }}
           {%if item.value is defined %}
-          value: {{ item.value }}
+          value: {{ item.value | string | to_json }}
           {% endif %}
           {%if item.valueFrom is defined %}
-          valueFrom: {{ item.valueFrom }}
+          valueFrom: {{ item.valueFrom | string | to_json }}
           {% endif %}
-          value: {{ item.value | string | to_json }}
 {% endfor %}
 {% endif %}
         image: "{{ rke2_kubevip_image }}"


### PR DESCRIPTION
# Description

Adding customizable defaults to the kube-vip template. This allows users that want to disable ARP mode in order to enable BGP mode ease to do so. This also adds support for using valueFrom in rke2_kubevip_args so reflected values can be included.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [X] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
No. (I'm new to ansible development and would be happy to test if someone could link me a document on how to do so)
