### PR TITLE
Update kube-vip.yml.j2 to stringify item.value

### DIFF
--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -73,7 +73,7 @@ spec:
 {% if rke2_kubevip_args  is defined %}
 {% for item in rke2_kubevip_args %}
         - name: {{ item.param }}
-          value: {{ item.value }}
+          value: {{ item.value | string | to_json }}
 {% endfor %}
 {% endif %}
         image: "{{ rke2_kubevip_image }}"


### PR DESCRIPTION
# Description

Convert item.value to JSON format in kube-vip.yml.j2 it could convert string value to number if the value looks like a number and causing issues
like 

rke2_kubevip_args:
  - param: KUBERNETES_SERVICE_HOST
    value: "127.0.0.1"
  - param: KUBERNETES_SERVICE_PORT
    value: "6443"


fix https://github.com/lablabs/ansible-role-rke2/issues/315

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
