### PR TITLE
fix: Don't mask services when /usr/local is read-only or has a dedicated mount point

### DIFF
--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -117,7 +117,7 @@
   ansible.builtin.systemd:
     name: "rke2-agent.service"
     enabled: false
-    masked: true
+    masked: "{{ (not usr_local.stat.writeable) or (partition_result.rc == 1) }}"
 
 - name: Wait for the first server be ready - no CNI
   ansible.builtin.shell: |

--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -63,7 +63,7 @@
   ansible.builtin.systemd:
     name: "rke2-{{ item }}.service"
     enabled: false
-    masked: true
+    masked: "{{ (not usr_local.stat.writeable) or (partition_result.rc == 1) }}"
   with_items:
     - "{{ (['agent', 'server'] | reject('match', rke2_type) | list) }}"
 


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->
Fix #395 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
Deploy on openSUSE MicroOS