### PR TITLE
Add configurable resources for kubevip DaemonSet and cloud-controller Pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ rke2_kubevip_upnp_enable: false
 # Enable kube-vip leader election for control plane load balancer
 rke2_kubevip_leaderelection_enable: true
 
+# Resources for kubevip DaemonSet Pods.
+rke2_kubevip_daemonset_resources: {}
+#  requests:
+#    memory: 40Mi
+
+# Resources for kubevip cloud controller Pods.
+rke2_kubevip_cloud_controller_resources: {}
+#  requests:
+#    memory: 40Mi
+
 # Add additional SANs in k8s API TLS cert
 rke2_additional_sans: []
 
@@ -429,7 +439,6 @@ rke2_service_cidr:
 
 # Enable SELinux for rke2
 rke2_selinux: false
-
 ```
 
 ## Inventory file example

--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ rke2_kubevip_service_election_enable: true
 # Prometheus metrics port for kube-vip
 rke2_kubevip_metrics_port: 2112
 
+# Resources for kubevip DaemonSet Pods.
+rke2_kubevip_daemonset_resources: {}
+#  requests:
+#    memory: 40Mi
+
+# Resources for kubevip cloud controller Pods.
+rke2_kubevip_cloud_controller_resources: {}
+#  requests:
+#    memory: 40Mi
+
 # Add additional SANs in k8s API TLS cert
 rke2_additional_sans: []
 
@@ -405,7 +415,6 @@ rke2_service_cidr:
 
 # Enable SELinux for rke2
 rke2_selinux: false
-
 ```
 
 ## Inventory file example

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,6 +82,16 @@ rke2_kubevip_service_election_enable: true
 # Prometheus metrics port for kube-vip
 rke2_kubevip_metrics_port: 2112
 
+# Resources for kubevip DaemonSet Pods.
+rke2_kubevip_daemonset_resources: {}
+#  requests:
+#    memory: 40Mi
+
+# Resources for kubevip cloud controller Pods.
+rke2_kubevip_cloud_controller_resources: {}
+#  requests:
+#    memory: 40Mi
+
 # Add additional SANs in k8s API TLS cert
 rke2_additional_sans: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -100,6 +100,16 @@ rke2_kubevip_upnp_enable: false
 # Enable kube-vip leader election for control plane load balancer
 rke2_kubevip_leaderelection_enable: true
 
+# Resources for kubevip DaemonSet Pods.
+rke2_kubevip_daemonset_resources: {}
+#  requests:
+#    memory: 40Mi
+
+# Resources for kubevip cloud controller Pods.
+rke2_kubevip_cloud_controller_resources: {}
+#  requests:
+#    memory: 40Mi
+
 # Add additional SANs in k8s API TLS cert
 rke2_additional_sans: []
 

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -128,6 +128,18 @@ argument_specs:
         elements: dict
         description: "A list of kube-vip flags. All flags can be found here https://kube-vip.io/docs/installation/flags/"
 
+      rke2_kubevip_daemonset_resources:
+        type: dict
+        default: {}
+        required: false
+        description: "Resources for kubevip DaemonSet Pods"
+
+      rke2_kubevip_cloud_controller_resources:
+        type: dict
+        default: {}
+        required: false
+        description: "Resources for kubevip cloud controller Pods"
+
       rke2_kubevip_metrics_port:
         type: int
         default: 2112

--- a/templates/kube-vip/kube-vip-cloud-controller.yml.j2
+++ b/templates/kube-vip/kube-vip-cloud-controller.yml.j2
@@ -61,7 +61,8 @@ spec:
         image: "{{ rke2_kubevip_cloud_provider_image }}"
         name: kube-vip-cloud-provider
         imagePullPolicy: Always
-        resources: {}
+        resources:
+{{ rke2_kubevip_cloud_controller_resources | to_nice_yaml | indent(10, first=True) }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -81,7 +81,8 @@ spec:
         ports:
         - name: metrics
           containerPort: {{ rke2_kubevip_metrics_port | int }}
-        resources: {}
+        resources:
+{{ rke2_kubevip_daemonset_resources | to_nice_yaml | indent(10, first=True) }}
         securityContext:
           capabilities:
             add:

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -86,7 +86,8 @@ spec:
         ports:
         - name: metrics
           containerPort: {{ rke2_kubevip_metrics_port | int }}
-        resources: {}
+        resources:
+{{ rke2_kubevip_daemonset_resources | to_nice_yaml | indent(10, first=True) }}
         securityContext:
           capabilities:
             add:


### PR DESCRIPTION
# Description

This change introduces new variables to set the resources for kubevip.

In our clusters we try to avoid any workloads with a QoS class of BestEffort. Specifically kubevip is important enough that it should run with proper resource requests.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
I've tested this with the default value of `{}`, which will not set any defaults, and with the example mentioned in `defaults/main.yaml`, which will properly set memory resource requests and cause the QoS class to change from BestEffort to Burstable.