### PR TITLE
feat: RKE2 Enable Conditional Image Imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ rke2_airgap_copy_additional_tarballs: []
 # Destination for airgap additional images tarballs ( see https://docs.rke2.io/install/airgap#tarball-method )
 rke2_tarball_images_path: "{{ rke2_data_path }}/agent/images"
 
+# Enable Conditional Image Imports - create a .cache.json file in the images directory so that
+# RKE2 only reimports tarballs that have changed (by size or mtime) since the last import, even
+# across restarts. Speeds up startup at the cost of guaranteed image reimport on every boot.
+# See https://docs.rke2.io/install/airgap?airgap-load-images=Manually+Deploy+Images#enable-conditional-image-imports
+rke2_conditional_image_imports: false
+
 # Architecture to be downloaded, currently there are releases for amd64 and s390x
 rke2_architecture: amd64
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -148,6 +148,12 @@ rke2_airgap_copy_additional_tarballs: []
 # Destination for airgap additional images tarballs ( see https://docs.rke2.io/install/airgap#tarball-method )
 rke2_tarball_images_path: "{{ rke2_data_path }}/agent/images"
 
+# Enable Conditional Image Imports - create a .cache.json file in the images directory so that
+# RKE2 only reimports tarballs that have changed (by size or mtime) since the last import, even
+# across restarts. Speeds up startup at the cost of guaranteed image reimport on every boot.
+# See https://docs.rke2.io/install/airgap?airgap-load-images=Manually+Deploy+Images#enable-conditional-image-imports
+rke2_conditional_image_imports: false
+
 # Architecture to be downloaded, currently there are releases for amd64 and s390x
 rke2_architecture: amd64
 

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -311,10 +311,19 @@
     - rke2_environment_options is defined
     - rke2_environment_options|length > 0
 
-- name: Enable Conditional Image Imports
-  when: rke2_conditional_image_imports
-  ansible.builtin.copy:
-    content: ""
-    dest: "{{ rke2_tarball_images_path }}/.cache.json"
-    mode: 0640
-    force: false
+- name: Conditional Image Imports
+  when: rke2_conditional_image_imports is defined
+  block:
+    - name: Enable Conditional Image Imports
+      ansible.builtin.copy:
+        content: ""
+        dest: "{{ rke2_tarball_images_path }}/.cache.json"
+        mode: 0640
+        force: false
+      when: rke2_conditional_image_imports
+
+    - name: Disable Conditional Image Imports
+      ansible.builtin.file:
+        path: "{{ rke2_tarball_images_path }}/.cache.json"
+        state: absent
+      when: not rke2_conditional_image_imports

--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -310,3 +310,11 @@
   when:
     - rke2_environment_options is defined
     - rke2_environment_options|length > 0
+
+- name: Enable Conditional Image Imports
+  when: rke2_conditional_image_imports
+  ansible.builtin.copy:
+    content: ""
+    dest: "{{ rke2_tarball_images_path }}/.cache.json"
+    mode: 0640
+    force: false


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->
Add support for conditional image imports on air-gap installation. This RKE2 feature can speed up RKE2 service startup at the cost of guaranteed image reimport on every boot.

This PR adds an option rke2_conditional_image_imports (default: false), so users can enable conditional image imports if they want.

See https://docs.rke2.io/install/airgap?airgap-load-images=Manually+Deploy+Images#enable-conditional-image-imports
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
