### PR TITLE
fix: s3 restore not triggered when s3_options defined

### DIFF
--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -50,7 +50,7 @@
   ansible.builtin.set_fact:
     do_etcd_restore_from_s3: true
   when:
-    - rke2_etcd_snapshot_file | length > 0
+    - rke2_etcd_snapshot_file | length == 0
     - rke2_etcd_snapshot_s3_options is defined
     - rke2_etcd_snapshot_s3_options.access_key
     - rke2_etcd_snapshot_s3_options.secret_key

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -168,9 +168,8 @@
 
     - name: Get all node names
       ansible.builtin.set_fact:
-        node_names: "{{ hostvars | dict2items | map(attribute='value.rke2_node_name') }}"
+        node_names: "{{ hostvars | dict2items | map(attribute='value.rke2_node_name') | list }}"
       run_once: true
-      register: node_names
 
     - name: Remove old <node>.node-password.rke2 secrets
       ansible.builtin.shell: |
@@ -179,7 +178,9 @@
       args:
         executable: /bin/bash
       with_items: "{{ registered_node_names.stdout_lines | difference(node_names) }}"
-      changed_when: false
+      changed_when: true
+      when: 
+        - item != rke2_node_name
 
     - name: Remove old nodes
       ansible.builtin.shell: |
@@ -188,7 +189,9 @@
       args:
         executable: /bin/bash
       with_items: "{{ registered_node_names.stdout_lines | difference(node_names) }}"
-      changed_when: false
+      changed_when: true
+      when: 
+        - item != rke2_node_name
 
 - name: Set an Active Server variable
   ansible.builtin.set_fact:

--- a/tasks/first_server.yml
+++ b/tasks/first_server.yml
@@ -179,7 +179,7 @@
         executable: /bin/bash
       with_items: "{{ registered_node_names.stdout_lines | difference(node_names) }}"
       changed_when: true
-      when: 
+      when:
         - item != rke2_node_name
 
     - name: Remove old nodes
@@ -190,7 +190,7 @@
         executable: /bin/bash
       with_items: "{{ registered_node_names.stdout_lines | difference(node_names) }}"
       changed_when: true
-      when: 
+      when:
         - item != rke2_node_name
 
 - name: Set an Active Server variable


### PR DESCRIPTION
# Description
When trying to restore etcd from s3: restore is not triggered.
In current state the `rke2_etcd_snapshot_file` is required for both filesystem and s3 restore, so 2 restores are done when defined.
In the PR s3 restore will be triggered only when `rke2_etcd_snapshot_file` is empty and `rke2_etcd_snapshot_s3_options` are defined.

When restore is triggered currently the role deletes first server (itself) from kube api so playbook hangs waiting forever. Cluster will not finish restore. The `set_fact` and `register` are both self excluding in this case, so the diff will always compare to empty list and all nodes are deleted from the cluster state. This also fixes the issue.

<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
Upgrading from very old role version to newest one brakes our restore run. After applying fixes all back to normal. And working as expected.

fixes #367