### PR TITLE
Update to fix valueFrom in kubevip args

### DIFF
--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -73,12 +73,12 @@ spec:
 {% if rke2_kubevip_args  is defined %}
 {% for item in rke2_kubevip_args %}
         - name: {{ item.param }}
-          {%if item.value is defined %}
+          {%- if item.value is defined %}
           value: {{ item.value | string | to_json }}
-          {% endif %}
-          {%if item.valueFrom is defined %}
-          valueFrom: {{ item.valueFrom | string | to_json }}
-          {% endif %}
+          {%- endif %}
+          {%- if item.valueFrom is defined %}
+          valueFrom: {{ item.valueFrom | to_json }}
+          {%- endif %}
 {% endfor %}
 {% endif %}
         image: "{{ rke2_kubevip_image }}"

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -31,54 +31,55 @@ spec:
         - manager
         env:
         - name: vip_arp
-          value: "{{ rke2_kubevip_arp_enable | default('true') | to_json }}"
+          value: "{{ rke2_kubevip_arp_enable | default('true') | string | to_yaml | trim }}"
         - name: vip_nodename
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
         - name: vip_interface
-          value: "{{ rke2_interface | default(ansible_facts.default_ipv4.interface | default(ansible_facts.default_ipv6.interface)) }}"
+          value: {{ rke2_interface | default(ansible_facts.default_ipv4.interface | default(ansible_facts.default_ipv6.interface)) | string | to_yaml | trim }}
         - name: port
-          value: "{{ rke2_api_port | default('6443') }}"
+          value: {{ rke2_api_port | default('6443') | string | to_yaml | trim }}
         - name: vip_cidr
-          value: "{{ rke2_api_cidr | default('24') }}"
+          value: {{ rke2_api_cidr | default('24') | string | to_yaml | trim }}
         - name: cp_enable
-          value: "{{ rke2_kubevip_cp_enable | default('true') | to_json }}"
+          value: {{ rke2_kubevip_cp_enable | default('true') | string | to_yaml | trim }}
         - name: cp_namespace
-          value: "{{ rke2_kubevip_cp_namespace | default('kube-system') }}"
+          value: {{ rke2_kubevip_cp_namespace | default('kube-system') | string | to_yaml | trim }}"
         - name: vip_ddns
-          value: "{{ rke2_kubevip_ddns_enable | default('false') | to_json  }}"
+          value: {{ rke2_kubevip_ddns_enable | default('false') | string | to_yaml | trim }}"
         - name: enableUPNP
-          value: "{{ rke2_kubevip_upnp_enable | default('false') | to_json  }}"
+          value: {{ rke2_kubevip_upnp_enable | default('false') | string | to_yaml | trim }}"
         - name: svc_enable
-          value: "{{ rke2_kubevip_svc_enable | to_json }}"
+          value: {{ rke2_kubevip_svc_enable | string | to_yaml | trim }}"
         - name: svc_election
-          value: "{{ rke2_kubevip_service_election_enable | to_json }}"
+          value: {{ rke2_kubevip_service_election_enable | string | to_yaml | trim }}"
         - name: vip_leaderelection
-          value: "{{ rke2_kubevip_leaderelection_enable | default('true') | to_json }}"
+          value: {{ rke2_kubevip_leaderelection_enable | default('true') | string | to_yaml | trim }}"
         - name: vip_leaseduration
-          value: "{{ rke2_kubevip_leaseduration | default('5') }}"
+          value: {{ rke2_kubevip_leaseduration | default('5') | string | to_yaml | trim }}"
         - name: vip_renewdeadline
-          value: "{{ rke2_kubevip_renewdeadline | default('3') }}"
+          value: {{ rke2_kubevip_renewdeadline | default('3') | string | to_yaml | trim }}"
         - name: vip_retryperiod
-          value: "{{ rke2_kubevip_retryperiod | default('1') }}"
+          value: {{ rke2_kubevip_retryperiod | default('1') | string | to_yaml | trim }}"
         - name: vip_loglevel
-          value: "{{ rke2_kubevip_loglevel | default('4') }}"
+          value: {{ rke2_kubevip_loglevel | default('4') | string | to_yaml | trim }}"
         - name: address
-          value: "{{ rke2_api_ip }}"
+          value: "{{ rke2_api_ip | string | to_yaml | trim }}"
         - name: prometheus_server
-          value: ":{{ rke2_kubevip_metrics_port }}"
+          value: ":{{ rke2_kubevip_metrics_port | int | to_yaml | trim }}"
         - name: lb_enable
-          value: "{{ rke2_kubevip_ipvs_lb_enable | to_json }}"
+          value: {{ rke2_kubevip_ipvs_lb_enable | string | to_yaml | trim }}
 {% if rke2_kubevip_args  is defined %}
 {% for item in rke2_kubevip_args %}
-        - name: {{ item.param }}
-          {%- if item.value is defined %}
-          value: {{ item.value | string | to_json }}
-          {%- endif %}
-          {%- if item.valueFrom is defined %}
-          valueFrom: {{ item.valueFrom | to_json }}
-          {%- endif %}
+        - name: {{ item.param | to_yaml(indent=8) -}}
+{% if item.value is defined %}
+          value: {{ item.value | string | to_yaml(default_flow_style=false, indent=10) -}}
+{% endif %}
+{% if item.valueFrom is defined %}
+          valueFrom: 
+            {{ item.valueFrom | to_nice_yaml(indent=10) | trim | indent(12) }}
+{% endif %}
 {% endfor %}
 {% endif %}
         image: "{{ rke2_kubevip_image }}"

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -31,7 +31,7 @@ spec:
         - manager
         env:
         - name: vip_arp
-          value: "{{ rke2_kubevip_arp_enable | default('true') | string | to_yaml | trim }}"
+          value: {{ rke2_kubevip_arp_enable | default('true') | string | to_yaml | trim }}
         - name: vip_nodename
           valueFrom:
             fieldRef:
@@ -45,27 +45,27 @@ spec:
         - name: cp_enable
           value: {{ rke2_kubevip_cp_enable | default('true') | string | to_yaml | trim }}
         - name: cp_namespace
-          value: {{ rke2_kubevip_cp_namespace | default('kube-system') | string | to_yaml | trim }}"
+          value: {{ rke2_kubevip_cp_namespace | default('kube-system') | string | to_yaml | trim }}
         - name: vip_ddns
-          value: {{ rke2_kubevip_ddns_enable | default('false') | string | to_yaml | trim }}"
+          value: {{ rke2_kubevip_ddns_enable | default('false') | string | to_yaml | trim }}
         - name: enableUPNP
-          value: {{ rke2_kubevip_upnp_enable | default('false') | string | to_yaml | trim }}"
+          value: {{ rke2_kubevip_upnp_enable | default('false') | string | to_yaml | trim }}
         - name: svc_enable
-          value: {{ rke2_kubevip_svc_enable | string | to_yaml | trim }}"
+          value: {{ rke2_kubevip_svc_enable | string | to_yaml | trim }}
         - name: svc_election
-          value: {{ rke2_kubevip_service_election_enable | string | to_yaml | trim }}"
+          value: {{ rke2_kubevip_service_election_enable | string | to_yaml | trim }}
         - name: vip_leaderelection
-          value: {{ rke2_kubevip_leaderelection_enable | default('true') | string | to_yaml | trim }}"
+          value: {{ rke2_kubevip_leaderelection_enable | default('true') | string | to_yaml | trim }}
         - name: vip_leaseduration
-          value: {{ rke2_kubevip_leaseduration | default('5') | string | to_yaml | trim }}"
+          value: {{ rke2_kubevip_leaseduration | default('5') | string | to_yaml | trim }}
         - name: vip_renewdeadline
-          value: {{ rke2_kubevip_renewdeadline | default('3') | string | to_yaml | trim }}"
+          value: {{ rke2_kubevip_renewdeadline | default('3') | string | to_yaml | trim }}
         - name: vip_retryperiod
-          value: {{ rke2_kubevip_retryperiod | default('1') | string | to_yaml | trim }}"
+          value: {{ rke2_kubevip_retryperiod | default('1') | string | to_yaml | trim }}
         - name: vip_loglevel
-          value: {{ rke2_kubevip_loglevel | default('4') | string | to_yaml | trim }}"
+          value: {{ rke2_kubevip_loglevel | default('4') | string | to_yaml | trim }}
         - name: address
-          value: "{{ rke2_api_ip | string | to_yaml | trim }}"
+          value: {{ rke2_api_ip | string | to_yaml | trim }}
         - name: prometheus_server
           value: ":{{ rke2_kubevip_metrics_port | int | to_yaml | trim }}"
         - name: lb_enable

--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -31,45 +31,45 @@ spec:
         - manager
         env:
         - name: vip_arp
-          value: {{ rke2_kubevip_arp_enable | default('true') | string | to_yaml | trim }}
+          value: "{{ rke2_kubevip_arp_enable | default('true') | to_json }}"
         - name: vip_nodename
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
         - name: vip_interface
-          value: {{ rke2_interface | default(ansible_facts.default_ipv4.interface | default(ansible_facts.default_ipv6.interface)) | string | to_yaml | trim }}
+          value: "{{ rke2_interface | default(ansible_facts.default_ipv4.interface | default(ansible_facts.default_ipv6.interface)) }}"
         - name: port
-          value: {{ rke2_api_port | default('6443') | string | to_yaml | trim }}
+          value: "{{ rke2_api_port | default('6443') }}"
         - name: vip_cidr
-          value: {{ rke2_api_cidr | default('24') | string | to_yaml | trim }}
+          value: "{{ rke2_api_cidr | default('24') }}"
         - name: cp_enable
-          value: {{ rke2_kubevip_cp_enable | default('true') | string | to_yaml | trim }}
+          value: "{{ rke2_kubevip_cp_enable | default('true') | to_json }}"
         - name: cp_namespace
-          value: {{ rke2_kubevip_cp_namespace | default('kube-system') | string | to_yaml | trim }}
+          value: "{{ rke2_kubevip_cp_namespace | default('kube-system') }}"
         - name: vip_ddns
-          value: {{ rke2_kubevip_ddns_enable | default('false') | string | to_yaml | trim }}
+          value: "{{ rke2_kubevip_ddns_enable | default('false') | to_json  }}"
         - name: enableUPNP
-          value: {{ rke2_kubevip_upnp_enable | default('false') | string | to_yaml | trim }}
+          value: "{{ rke2_kubevip_upnp_enable | default('false') | to_json  }}"
         - name: svc_enable
-          value: {{ rke2_kubevip_svc_enable | string | to_yaml | trim }}
+          value: "{{ rke2_kubevip_svc_enable | to_json }}"
         - name: svc_election
-          value: {{ rke2_kubevip_service_election_enable | string | to_yaml | trim }}
+          value: "{{ rke2_kubevip_service_election_enable | to_json }}"
         - name: vip_leaderelection
-          value: {{ rke2_kubevip_leaderelection_enable | default('true') | string | to_yaml | trim }}
+          value: "{{ rke2_kubevip_leaderelection_enable | default('true') | to_json }}"
         - name: vip_leaseduration
-          value: {{ rke2_kubevip_leaseduration | default('5') | string | to_yaml | trim }}
+          value: "{{ rke2_kubevip_leaseduration | default('5') }}"
         - name: vip_renewdeadline
-          value: {{ rke2_kubevip_renewdeadline | default('3') | string | to_yaml | trim }}
+          value: "{{ rke2_kubevip_renewdeadline | default('3') }}"
         - name: vip_retryperiod
-          value: {{ rke2_kubevip_retryperiod | default('1') | string | to_yaml | trim }}
+          value: "{{ rke2_kubevip_retryperiod | default('1') }}"
         - name: vip_loglevel
-          value: {{ rke2_kubevip_loglevel | default('4') | string | to_yaml | trim }}
+          value: "{{ rke2_kubevip_loglevel | default('4') }}"
         - name: address
-          value: {{ rke2_api_ip | string | to_yaml | trim }}
+          value: "{{ rke2_api_ip }}"
         - name: prometheus_server
-          value: ":{{ rke2_kubevip_metrics_port | int | to_yaml | trim }}"
+          value: ":{{ rke2_kubevip_metrics_port }}"
         - name: lb_enable
-          value: {{ rke2_kubevip_ipvs_lb_enable | string | to_yaml | trim }}
+          value: "{{ rke2_kubevip_ipvs_lb_enable | to_json }}"
 {% if rke2_kubevip_args  is defined %}
 {% for item in rke2_kubevip_args %}
         - name: {{ item.param | to_yaml(indent=8) -}}


### PR DESCRIPTION
Fixes:
  - whitespace generation that creates poorly formatted files. 
  - valueFrom should not be quoted as it generates broken files.

# Description

When generating the blob from the template, the resulting file is currently generated in a poorly formatted way. Additionally, valueFrom is quoted in multiple places which results in a file that cannot be installed into the cluster.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
It isn't. I don't know how to test this without creating a new release. It should be easy to test by applying with any kubevip args.
