### PR TITLE
Refactor environment variable values to use string conversion

### DIFF
--- a/templates/kube-vip/kube-vip.yml.j2
+++ b/templates/kube-vip/kube-vip.yml.j2
@@ -31,45 +31,45 @@ spec:
         - manager
         env:
         - name: vip_arp
-          value: "{{ rke2_kubevip_arp_enable | default('true') | to_json }}"
+          value: {{ rke2_kubevip_arp_enable | default('true') | string | to_yaml | trim }}
         - name: vip_nodename
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
         - name: vip_interface
-          value: "{{ rke2_interface | default(ansible_facts.default_ipv4.interface | default(ansible_facts.default_ipv6.interface)) }}"
+          value: {{ rke2_interface | default(ansible_facts.default_ipv4.interface | default(ansible_facts.default_ipv6.interface)) | string | to_yaml | trim }}
         - name: port
-          value: "{{ rke2_api_port | default('6443') }}"
+          value: {{ rke2_api_port | default('6443') | string | to_yaml | trim }}
         - name: vip_cidr
-          value: "{{ rke2_api_cidr | default('24') }}"
+          value: {{ rke2_api_cidr | default('24') | string | to_yaml | trim }}
         - name: cp_enable
-          value: "{{ rke2_kubevip_cp_enable | default('true') | to_json }}"
+          value: {{ rke2_kubevip_cp_enable | default('true') | string | to_yaml | trim }}
         - name: cp_namespace
-          value: "{{ rke2_kubevip_cp_namespace | default('kube-system') }}"
+          value: {{ rke2_kubevip_cp_namespace | default('kube-system') | string | to_yaml | trim }}
         - name: vip_ddns
-          value: "{{ rke2_kubevip_ddns_enable | default('false') | to_json  }}"
+          value: {{ rke2_kubevip_ddns_enable | default('false') | string | to_yaml | trim }}
         - name: enableUPNP
-          value: "{{ rke2_kubevip_upnp_enable | default('false') | to_json  }}"
+          value: {{ rke2_kubevip_upnp_enable | default('false') | string | to_yaml | trim }}
         - name: svc_enable
-          value: "{{ rke2_kubevip_svc_enable | to_json }}"
+          value: {{ rke2_kubevip_svc_enable | string | to_yaml | trim }}
         - name: svc_election
-          value: "{{ rke2_kubevip_service_election_enable | to_json }}"
+          value: {{ rke2_kubevip_service_election_enable | string | to_yaml | trim }}
         - name: vip_leaderelection
-          value: "{{ rke2_kubevip_leaderelection_enable | default('true') | to_json }}"
+          value: {{ rke2_kubevip_leaderelection_enable | default('true') | string | to_yaml | trim }}
         - name: vip_leaseduration
-          value: "{{ rke2_kubevip_leaseduration | default('5') }}"
+          value: {{ rke2_kubevip_leaseduration | default('5') | string | to_yaml | trim }}
         - name: vip_renewdeadline
-          value: "{{ rke2_kubevip_renewdeadline | default('3') }}"
+          value: {{ rke2_kubevip_renewdeadline | default('3') | string | to_yaml | trim }}
         - name: vip_retryperiod
-          value: "{{ rke2_kubevip_retryperiod | default('1') }}"
+          value: {{ rke2_kubevip_retryperiod | default('1') | string | to_yaml | trim }}
         - name: vip_loglevel
-          value: "{{ rke2_kubevip_loglevel | default('4') }}"
+          value: {{ rke2_kubevip_loglevel | default('4') | string | to_yaml | trim }}
         - name: address
-          value: "{{ rke2_api_ip }}"
+          value: {{ rke2_api_ip | string | to_yaml | trim }}
         - name: prometheus_server
-          value: ":{{ rke2_kubevip_metrics_port }}"
+          value: ":{{ rke2_kubevip_metrics_port | int | to_yaml | trim }}"
         - name: lb_enable
-          value: "{{ rke2_kubevip_ipvs_lb_enable | to_json }}"
+          value: {{ rke2_kubevip_ipvs_lb_enable | string | to_yaml | trim }}
 {% if rke2_kubevip_args  is defined %}
 {% for item in rke2_kubevip_args %}
         - name: {{ item.param }}


### PR DESCRIPTION
# Description

This replaces the usage of `to_json` with the more correct `to_yaml`. It also enforces type conversion to string for most variables to ensure proper quoting is retained into the objects. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Tested _lightly_ with ` https://ansible.sivel.net/test/` but probably needs more robust testing before merging due to what is being changed. 